### PR TITLE
update iris.py to fix test_size error

### DIFF
--- a/qiskit_machine_learning/datasets/iris.py
+++ b/qiskit_machine_learning/datasets/iris.py
@@ -28,7 +28,7 @@ def iris(training_size, test_size, n, plot_data=False, one_hot=True):
     class_labels = [r'A', r'B', r'C']
     data, target = datasets.load_iris(return_X_y=True)
     sample_train, sample_test, label_train, label_test = \
-        train_test_split(data, target, test_size=1, random_state=42)
+        train_test_split(data, target, test_size=test_size, random_state=42)
 
     # Now we standardize for gaussian around 0 with unit variance
     std_scale = StandardScaler().fit(sample_train)


### PR DESCRIPTION
Changed the value of the test_size attribute on the train_test_split() function fro the hardcoded 1 that causes bugs to the given parameter.
#36 should be fixed by this

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

fix to #36 that should patch up the issue by now allowing train_test_split() to  use the test_size argument passed to the iris class


### Details and comments


