### PR TITLE
Add missing black settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.black]
+line-length = 100
+target-version = ['py36', 'py37', 'py38', 'py39']

--- a/qiskit_machine_learning/algorithms/classifiers/neural_network_classifier.py
+++ b/qiskit_machine_learning/algorithms/classifiers/neural_network_classifier.py
@@ -175,10 +175,7 @@ class NeuralNetworkClassifier(ClassifierMixin):
                         # TODO: do batch eval
                         y_predict = self._neural_network.forward(x, w)
                         _, weight_prob_grad = self._neural_network.backward(x, w)
-                        grad += (
-                            self._loss.gradient(y_predict[0], y_target)
-                            @ weight_prob_grad[0, :]
-                        )
+                        grad += self._loss.gradient(y_predict[0], y_target) @ weight_prob_grad[0, :]
                     return grad
 
             else:
@@ -198,9 +195,9 @@ class NeuralNetworkClassifier(ClassifierMixin):
                         # TODO: do batch eval
                         _, weight_prob_grad = self._neural_network.backward(x, w)
                         for i in range(num_classes):
-                            grad += weight_prob_grad[0, i, :].reshape(
-                                grad.shape
-                            ) * self._loss(i, y_target)
+                            grad += weight_prob_grad[0, i, :].reshape(grad.shape) * self._loss(
+                                i, y_target
+                            )
                     return grad
 
         if self._warm_start and self._fit_result is not None:
@@ -228,9 +225,7 @@ class NeuralNetworkClassifier(ClassifierMixin):
             The predicted classes.
         """
         if self._fit_result is None:
-            raise QiskitMachineLearningError(
-                "Model needs to be fit to some training data first!"
-            )
+            raise QiskitMachineLearningError("Model needs to be fit to some training data first!")
         if self._neural_network.output_shape == (1,):
             predict = np.sign(self._neural_network.forward(X, self._fit_result[0]))
         else:

--- a/qiskit_machine_learning/algorithms/classifiers/vqc.py
+++ b/qiskit_machine_learning/algorithms/classifiers/vqc.py
@@ -66,26 +66,20 @@ class VQC(NeuralNetworkClassifier):
             num_qubits_ = num_qubits
             if feature_map:
                 if feature_map.num_qubits != num_qubits:
-                    raise QiskitMachineLearningError(
-                        "Incompatible num_qubits and feature_map!"
-                    )
+                    raise QiskitMachineLearningError("Incompatible num_qubits and feature_map!")
                 feature_map_ = feature_map
             else:
                 feature_map_ = ZZFeatureMap(num_qubits)
             if ansatz:
                 if ansatz.num_qubits != num_qubits:
-                    raise QiskitMachineLearningError(
-                        "Incompatible num_qubits and ansatz!"
-                    )
+                    raise QiskitMachineLearningError("Incompatible num_qubits and ansatz!")
                 ansatz_ = ansatz
             else:
                 ansatz_ = RealAmplitudes(num_qubits)
         else:
             if feature_map and ansatz:
                 if feature_map.num_qubits != ansatz.num_qubits:
-                    raise QiskitMachineLearningError(
-                        "Incompatible feature_map and ansatz!"
-                    )
+                    raise QiskitMachineLearningError("Incompatible feature_map and ansatz!")
                 feature_map_ = feature_map
                 ansatz_ = ansatz
                 num_qubits_ = feature_map.num_qubits

--- a/qiskit_machine_learning/algorithms/distribution_learners/qgan/numpy_discriminator.py
+++ b/qiskit_machine_learning/algorithms/distribution_learners/qgan/numpy_discriminator.py
@@ -60,17 +60,11 @@ class DiscriminatorNet:
             activ_function_curr = layer["activation"]
             layer_input_size = layer["input_dim"]
             layer_output_size = layer["output_dim"]
-            params_layer = algorithm_globals.random.random(
-                layer_output_size * layer_input_size
-            )
+            params_layer = algorithm_globals.random.random(layer_output_size * layer_input_size)
             if activ_function_curr == "leaky_relu":
-                params_layer = (
-                    params_layer * 2 - np.ones(np.shape(params_layer))
-                ) * 0.7
+                params_layer = (params_layer * 2 - np.ones(np.shape(params_layer))) * 0.7
             elif activ_function_curr == "sigmoid":
-                params_layer = (
-                    params_layer * 2 - np.ones(np.shape(params_layer))
-                ) * 0.2
+                params_layer = (params_layer * 2 - np.ones(np.shape(params_layer))) * 0.2
             else:
                 params_layer = params_layer * 2 - np.ones(np.shape(params_layer))
             self.parameters = np.append(self.parameters, params_layer)
@@ -123,9 +117,7 @@ class DiscriminatorNet:
             w_curr = self.parameters[pointer:pointer_next]
             w_curr = np.reshape(w_curr, (layer_output_size, layer_input_size))
             pointer = pointer_next
-            x_new, z_curr = single_layer_forward_propagation(
-                x_old, w_curr, activ_function_curr
-            )
+            x_new, z_curr = single_layer_forward_propagation(x_old, w_curr, activ_function_curr)
 
             self.memory["a" + str(idx)] = x_old
             self.memory["z" + str(layer_idx)] = z_curr
@@ -290,9 +282,7 @@ class NumPyDiscriminator(DiscriminativeNetwork):
         self._discriminator.architecture = np.load(
             os.path.join(load_dir, "np_discriminator_architecture.csv")
         )
-        self._discriminator.memory = np.load(
-            os.path.join(load_dir, "np_discriminator_memory.csv")
-        )
+        self._discriminator.memory = np.load(os.path.join(load_dir, "np_discriminator_memory.csv"))
         self._discriminator.parameters = np.load(
             os.path.join(load_dir, "np_discriminator_params.csv")
         )
@@ -312,9 +302,7 @@ class NumPyDiscriminator(DiscriminativeNetwork):
     def discriminator_net(self, net):
         self._discriminator = net
 
-    def get_label(
-        self, x, detach=False
-    ):  # pylint: disable=arguments-differ,unused-argument
+    def get_label(self, x, detach=False):  # pylint: disable=arguments-differ,unused-argument
         """
         Get data sample labels, i.e. true or fake.
 
@@ -346,11 +334,7 @@ class NumPyDiscriminator(DiscriminativeNetwork):
                 np.multiply(y, np.log(np.maximum(np.ones(np.shape(x)) * 1e-4, x)))
                 + np.multiply(
                     np.ones(np.shape(y)) - y,
-                    np.log(
-                        np.maximum(
-                            np.ones(np.shape(x)) * 1e-4, np.ones(np.shape(x)) - x
-                        )
-                    ),
+                    np.log(np.maximum(np.ones(np.shape(x)) * 1e-4, np.ones(np.shape(x)) - x)),
                 ),
                 weights,
             )
@@ -360,11 +344,7 @@ class NumPyDiscriminator(DiscriminativeNetwork):
                 np.multiply(y, np.log(np.maximum(np.ones(np.shape(x)) * 1e-4, x)))
                 + np.multiply(
                     np.ones(np.shape(y)) - y,
-                    np.log(
-                        np.maximum(
-                            np.ones(np.shape(x)) * 1e-4, np.ones(np.shape(x)) - x
-                        )
-                    ),
+                    np.log(np.maximum(np.ones(np.shape(x)) * 1e-4, np.ones(np.shape(x)) - x)),
                 )
             )
 
@@ -388,9 +368,7 @@ class NumPyDiscriminator(DiscriminativeNetwork):
             self._discriminator.parameters = params
             # Train on Real Data
             prediction_real = self.get_label(real_batch)
-            loss_real = self.loss(
-                prediction_real, np.ones(np.shape(prediction_real)), real_prob
-            )
+            loss_real = self.loss(prediction_real, np.ones(np.shape(prediction_real)), real_prob)
             prediction_fake = self.get_label(generated_batch)
             loss_fake = self.loss(
                 prediction_fake, np.zeros(np.shape(prediction_fake)), generated_prob

--- a/qiskit_machine_learning/algorithms/distribution_learners/qgan/pytorch_discriminator.py
+++ b/qiskit_machine_learning/algorithms/distribution_learners/qgan/pytorch_discriminator.py
@@ -65,9 +65,7 @@ class PyTorchDiscriminator(DiscriminativeNetwork):
         self._discriminator = DiscriminatorNet(self._n_features, self._n_out)
         # optimizer: torch.optim.Optimizer or None, Optimizer initialized w.r.t
         # discriminator network parameters.
-        self._optimizer = optim.Adam(
-            self._discriminator.parameters(), lr=1e-5, amsgrad=True
-        )
+        self._optimizer = optim.Adam(self._discriminator.parameters(), lr=1e-5, amsgrad=True)
 
         self._ret = {}  # type: Dict[str, Any]
 
@@ -179,9 +177,9 @@ class PyTorchDiscriminator(DiscriminativeNetwork):
         z = Variable(x + delta_, requires_grad=True)
         o_l = self.get_label(z)
         # pylint: disable=no-member
-        d_g = torch.autograd.grad(
-            o_l, z, grad_outputs=torch.ones(o_l.size()), create_graph=True
-        )[0].view(z.size(0), -1)
+        d_g = torch.autograd.grad(o_l, z, grad_outputs=torch.ones(o_l.size()), create_graph=True)[
+            0
+        ].view(z.size(0), -1)
 
         return lambda_ * ((d_g.norm(p=2, dim=1) - k) ** 2).mean()
 
@@ -229,15 +227,11 @@ class PyTorchDiscriminator(DiscriminativeNetwork):
         prediction_real = self.get_label(real_batch)
 
         # Calculate error and back propagate
-        error_real = self.loss(
-            prediction_real, torch.ones(len(prediction_real), 1), real_prob
-        )
+        error_real = self.loss(prediction_real, torch.ones(len(prediction_real), 1), real_prob)
         error_real.backward()
 
         # Train on Generated Data
-        generated_batch = np.reshape(
-            generated_batch, (len(generated_batch), self._n_features)
-        )
+        generated_batch = np.reshape(generated_batch, (len(generated_batch), self._n_features))
         generated_prob = np.reshape(generated_prob, (len(generated_prob), 1))
         generated_prob = torch.tensor(generated_prob, dtype=torch.float32)
         prediction_fake = self.get_label(generated_batch)

--- a/qiskit_machine_learning/algorithms/distribution_learners/qgan/qgan.py
+++ b/qiskit_machine_learning/algorithms/distribution_learners/qgan/qgan.py
@@ -193,7 +193,7 @@ class QGAN:
         """
         if quantum_instance is None and self.quantum_instance is None:
             raise QiskitMachineLearningError(
-                "A QuantumInstance or Backend " "must be supplied to run the quantum algorithm."
+                "A QuantumInstance or Backend must be supplied to run the quantum algorithm."
             )
         if isinstance(quantum_instance, (BaseBackend, Backend)):
             self.set_backend(quantum_instance, **kwargs)

--- a/qiskit_machine_learning/algorithms/distribution_learners/qgan/qgan.py
+++ b/qiskit_machine_learning/algorithms/distribution_learners/qgan/qgan.py
@@ -179,7 +179,7 @@ class QGAN:
     def run(
         self,
         quantum_instance: Optional[Union[QuantumInstance, Backend, BaseBackend]] = None,
-        **kwargs
+        **kwargs,
     ) -> Dict:
         """Execute the algorithm with selected backend.
         Args:
@@ -193,8 +193,7 @@ class QGAN:
         """
         if quantum_instance is None and self.quantum_instance is None:
             raise QiskitMachineLearningError(
-                "A QuantumInstance or Backend "
-                "must be supplied to run the quantum algorithm."
+                "A QuantumInstance or Backend " "must be supplied to run the quantum algorithm."
             )
         if isinstance(quantum_instance, (BaseBackend, Backend)):
             self.set_backend(quantum_instance, **kwargs)
@@ -386,9 +385,7 @@ class QGAN:
                                         items in the truncated data set
         """
         if self._snapshot_dir is not None:
-            with open(
-                os.path.join(self._snapshot_dir, "output.csv"), mode="w"
-            ) as csv_file:
+            with open(os.path.join(self._snapshot_dir, "output.csv"), mode="w") as csv_file:
                 fieldnames = [
                     "epoch",
                     "loss_discriminator",
@@ -424,9 +421,7 @@ class QGAN:
 
                 # 2. Train Generator
                 self._generator.discriminator = self._discriminator
-                ret_g = self._generator.train(
-                    self._quantum_instance, shots=self._batch_size
-                )
+                ret_g = self._generator.train(self._quantum_instance, shots=self._batch_size)
                 g_loss_min = ret_g["loss"]
 
             self._d_loss.append(np.around(float(d_loss_min), 4))
@@ -465,9 +460,7 @@ class QGAN:
         Raises:
             QiskitMachineLearningError: invalid backend
         """
-        if self._quantum_instance.backend_name == (
-            "unitary_simulator" or "clifford_simulator"
-        ):
+        if self._quantum_instance.backend_name == ("unitary_simulator" or "clifford_simulator"):
             raise QiskitMachineLearningError(
                 "Chosen backend not supported - "
                 "Set backend either to statevector_simulator, qasm_simulator"

--- a/qiskit_machine_learning/algorithms/distribution_learners/qgan/quantum_generator.py
+++ b/qiskit_machine_learning/algorithms/distribution_learners/qgan/quantum_generator.py
@@ -80,22 +80,17 @@ class QuantumGenerator(GenerativeNetwork):
         if generator_circuit is None:
             circuit = QuantumCircuit(sum(num_qubits))
             circuit.h(circuit.qubits)
-            ansatz = TwoLocal(
-                sum(num_qubits), "ry", "cz", reps=1, entanglement="circular"
-            )
+            ansatz = TwoLocal(sum(num_qubits), "ry", "cz", reps=1, entanglement="circular")
             circuit.compose(ansatz, inplace=True)
 
             # Set generator circuit
             self.generator_circuit = circuit
 
-        self._free_parameters = sorted(
-            self.generator_circuit.parameters, key=lambda p: p.name
-        )
+        self._free_parameters = sorted(self.generator_circuit.parameters, key=lambda p: p.name)
 
         if init_params is None:
             init_params = (
-                algorithm_globals.random.random(self.generator_circuit.num_parameters)
-                * 2e-2
+                algorithm_globals.random.random(self.generator_circuit.num_parameters) * 2e-2
             )
 
         self._bound_parameters = init_params
@@ -223,8 +218,7 @@ class QuantumGenerator(GenerativeNetwork):
                 self._optimizer = optimizer
             else:
                 raise QiskitMachineLearningError(
-                    "Please provide an Optimizer object to use"
-                    "as the generator optimizer."
+                    "Please provide an Optimizer object to use" "as the generator optimizer."
                 )
         else:
             self._optimizer = ADAM(
@@ -391,9 +385,7 @@ class QuantumGenerator(GenerativeNetwork):
 
         return objective_function
 
-    def _convert_to_gradient_function(
-        self, gradient_object, quantum_instance, discriminator
-    ):
+    def _convert_to_gradient_function(self, gradient_object, quantum_instance, discriminator):
         """
         Convert to gradient function
 
@@ -427,12 +419,8 @@ class QuantumGenerator(GenerativeNetwork):
             prediction_generated = discriminator.get_label(generated_data, detach=True)
             op = ~CircuitStateFn(primitive=self.generator_circuit)
             grad_object = gradient_object.convert(operator=op, params=free_params)
-            value_dict = {
-                free_params[i]: current_point[i] for i in range(len(free_params))
-            }
-            analytical_gradients = np.array(
-                grad_object.assign_parameters(value_dict).eval()
-            )
+            value_dict = {free_params[i]: current_point[i] for i in range(len(free_params))}
+            analytical_gradients = np.array(grad_object.assign_parameters(value_dict).eval())
             loss_gradients = self.loss(
                 prediction_generated, np.transpose(analytical_gradients)
             ).real

--- a/qiskit_machine_learning/algorithms/distribution_learners/qgan/quantum_generator.py
+++ b/qiskit_machine_learning/algorithms/distribution_learners/qgan/quantum_generator.py
@@ -218,7 +218,7 @@ class QuantumGenerator(GenerativeNetwork):
                 self._optimizer = optimizer
             else:
                 raise QiskitMachineLearningError(
-                    "Please provide an Optimizer object to use" "as the generator optimizer."
+                    "Please provide an Optimizer object to use as the generator optimizer."
                 )
         else:
             self._optimizer = ADAM(

--- a/qiskit_machine_learning/algorithms/regressors/neural_network_regressor.py
+++ b/qiskit_machine_learning/algorithms/regressors/neural_network_regressor.py
@@ -160,9 +160,9 @@ class NeuralNetworkRegressor(RegressorMixin):
                     # TODO: do batch eval
                     _, weight_prob_grad = self._neural_network.backward(x, w)
                     for i in range(num_classes):
-                        grad += weight_prob_grad[0, i, :].reshape(
-                            grad.shape
-                        ) * self._loss(i, y_target)
+                        grad += weight_prob_grad[0, i, :].reshape(grad.shape) * self._loss(
+                            i, y_target
+                        )
                 return grad
 
         if self._warm_start and self._fit_result is not None:
@@ -191,9 +191,7 @@ class NeuralNetworkRegressor(RegressorMixin):
         """
 
         if self._fit_result is None:
-            raise QiskitMachineLearningError(
-                "Model needs to be fit to some training data first!"
-            )
+            raise QiskitMachineLearningError("Model needs to be fit to some training data first!")
 
         # TODO: proper handling of batching
         return self._neural_network.forward(X, self._fit_result[0])

--- a/qiskit_machine_learning/circuit/library/raw_feature_vector.py
+++ b/qiskit_machine_learning/circuit/library/raw_feature_vector.py
@@ -92,9 +92,7 @@ class RawFeatureVector(BlueprintCircuit):
             self._ordered_parameters.resize(self.feature_dimension)
         elif len(self._ordered_parameters) != self.feature_dimension:
             if raise_on_failure:
-                raise ValueError(
-                    "Mismatching number of parameters and feature dimension."
-                )
+                raise ValueError("Mismatching number of parameters and feature dimension.")
             return False
         return True
 
@@ -169,9 +167,7 @@ class ParameterizedInitialize(Instruction):
             if len(param.parameters) == 0:
                 cleaned_params.append(complex(param))
             else:
-                raise QiskitError(
-                    "Cannot define a ParameterizedInitialize with unbound parameters"
-                )
+                raise QiskitError("Cannot define a ParameterizedInitialize with unbound parameters")
 
         # normalize
         normalized = np.array(cleaned_params) / np.linalg.norm(cleaned_params)

--- a/qiskit_machine_learning/connectors/torch_connector.py
+++ b/qiskit_machine_learning/connectors/torch_connector.py
@@ -139,9 +139,7 @@ class TorchConnector(Module):
                 )
 
             # evaluate QNN gradient
-            input_grad, weights_grad = neural_network.backward(
-                input_data.numpy(), weights.numpy()
-            )
+            input_grad, weights_grad = neural_network.backward(input_data.numpy(), weights.numpy())
             if input_grad is not None:
                 if np.prod(input_grad.shape) == 0:
                     input_grad = None
@@ -151,17 +149,13 @@ class TorchConnector(Module):
                     # cast to dense here, since PyTorch does not support sparse output yet.
                     # this should only happen if the network returns sparse output but the
                     # connector is configured to return dense output.
-                    input_grad = (
-                        input_grad.to_dense()
-                    )  # this should be eventually removed
+                    input_grad = input_grad.to_dense()  # this should be eventually removed
                     input_grad = input_grad.to(grad_output.dtype)
                 else:
                     input_grad = Tensor(input_grad).to(grad_output.dtype)
 
                 if len(grad_output.shape) == 2:
-                    input_grad = grad_output.transpose(0, 1) @ input_grad.transpose(
-                        0, 1
-                    )
+                    input_grad = grad_output.transpose(0, 1) @ input_grad.transpose(0, 1)
                 else:
                     input_grad = grad_output @ input_grad  # TODO: validate
 
@@ -169,24 +163,18 @@ class TorchConnector(Module):
                 if np.prod(weights_grad.shape) == 0:
                     weights_grad = None
                 elif neural_network.sparse:
-                    weights_grad = sparse_coo_tensor(
-                        weights_grad.coords, weights_grad.data
-                    )
+                    weights_grad = sparse_coo_tensor(weights_grad.coords, weights_grad.data)
 
                     # cast to dense here, since PyTorch does not support sparse output yet.
                     # this should only happen if the network returns sparse output but the
                     # connector is configured to return dense output.
-                    weights_grad = (
-                        weights_grad.to_dense()
-                    )  # this should be eventually removed
+                    weights_grad = weights_grad.to_dense()  # this should be eventually removed
                     weights_grad = weights_grad.to(grad_output.dtype)
                 else:
                     weights_grad = Tensor(weights_grad).to(grad_output.dtype)
 
                 if len(grad_output.shape) == 2:
-                    weights_grad = grad_output.transpose(0, 1) @ weights_grad.transpose(
-                        0, 1
-                    )
+                    weights_grad = grad_output.transpose(0, 1) @ weights_grad.transpose(0, 1)
                 else:
                     weights_grad = grad_output @ weights_grad
 

--- a/qiskit_machine_learning/datasets/ad_hoc.py
+++ b/qiskit_machine_learning/datasets/ad_hoc.py
@@ -46,9 +46,7 @@ def ad_hoc_data(
     sample_a = [[0 for x in range(n)] for y in range(training_size + test_size)]
     sample_b = [[0 for x in range(n)] for y in range(training_size + test_size)]
 
-    sample_total = [
-        [[0 for x in range(count)] for y in range(count)] for z in range(count)
-    ]
+    sample_total = [[[0 for x in range(count)] for y in range(count)] for z in range(count)]
 
     # interactions = np.transpose(np.array([[1, 0], [0, 1], [1, 1]]))
 
@@ -162,9 +160,7 @@ def ad_hoc_data(
             for k, key in enumerate(class_labels)
         }
         test_input = {
-            key: (sample_train[label_train == k, :])[
-                training_size : (training_size + test_size)
-            ]
+            key: (sample_train[label_train == k, :])[training_size : (training_size + test_size)]
             for k, key in enumerate(class_labels)
         }
 
@@ -200,20 +196,12 @@ def ad_hoc_data(
                         x_1 * np.kron(np.kron(z_m, j_m), j_m)
                         + x_2 * np.kron(np.kron(j_m, z_m), j_m)
                         + x_3 * np.kron(np.kron(j_m, j_m), z_m)
-                        + (np.pi - x_1)
-                        * (np.pi - x_2)
-                        * np.kron(np.kron(z_m, z_m), j_m)
-                        + (np.pi - x_2)
-                        * (np.pi - x_3)
-                        * np.kron(np.kron(j_m, z_m), z_m)
-                        + (np.pi - x_1)
-                        * (np.pi - x_3)
-                        * np.kron(np.kron(z_m, j_m), z_m)
+                        + (np.pi - x_1) * (np.pi - x_2) * np.kron(np.kron(z_m, z_m), j_m)
+                        + (np.pi - x_2) * (np.pi - x_3) * np.kron(np.kron(j_m, z_m), z_m)
+                        + (np.pi - x_1) * (np.pi - x_3) * np.kron(np.kron(z_m, j_m), z_m)
                     )
                     u_u = scipy.linalg.expm(1j * phi)  # pylint: disable=no-member
-                    psi = (
-                        np.asmatrix(u_u) * h_3 * np.asmatrix(u_u) * np.transpose(psi_0)
-                    )
+                    psi = np.asmatrix(u_u) * h_3 * np.asmatrix(u_u) * np.transpose(psi_0)
                     temp = np.real(psi.getH() * m_m * psi).item()
                     if temp > gap:
                         sample_total[n_1][n_2][n_3] = +1
@@ -265,9 +253,7 @@ def ad_hoc_data(
             for k, key in enumerate(class_labels)
         }
         test_input = {
-            key: (sample_train[label_train == k, :])[
-                training_size : (training_size + test_size)
-            ]
+            key: (sample_train[label_train == k, :])[training_size : (training_size + test_size)]
             for k, key in enumerate(class_labels)
         }
 
@@ -376,8 +362,5 @@ def sample_ad_hoc_data(sample_total, test_size, n):
         label_train[test_size + lindex] = 1
     label_train = label_train.astype(int)
     sample_train = np.reshape(sample_train, (2 * test_size, n))
-    test_input = {
-        key: (sample_train[label_train == k, :])[:]
-        for k, key in enumerate(class_labels)
-    }
+    test_input = {key: (sample_train[label_train == k, :])[:] for k, key in enumerate(class_labels)}
     return test_input

--- a/qiskit_machine_learning/datasets/breast_cancer.py
+++ b/qiskit_machine_learning/datasets/breast_cancer.py
@@ -53,8 +53,7 @@ def breast_cancer(training_size, test_size, n, plot_data=False, one_hot=True):
         for k, key in enumerate(class_labels)
     }
     test_input = {
-        key: (sample_test[label_test == k, :])[:test_size]
-        for k, key in enumerate(class_labels)
+        key: (sample_test[label_test == k, :])[:test_size] for k, key in enumerate(class_labels)
     }
     training_feature_array, training_label_array = features_and_labels_transform(
         training_input, class_labels, one_hot

--- a/qiskit_machine_learning/datasets/dataset_helper.py
+++ b/qiskit_machine_learning/datasets/dataset_helper.py
@@ -68,9 +68,7 @@ def discretize_and_truncate(
     """
     # Truncate the data
     if np.ndim(min_max_bin_centers) == 1:
-        min_max_bin_centers = np.reshape(
-            min_max_bin_centers, (1, len(min_max_bin_centers))
-        )
+        min_max_bin_centers = np.reshape(min_max_bin_centers, (1, len(min_max_bin_centers)))
 
     data = data.reshape((len(data), len(num_qubits)))
     temp = []
@@ -129,9 +127,7 @@ def discretize_and_truncate(
 
     if return_prob:
         if np.ndim(data) > 1:
-            prob_data = np.zeros(
-                int(np.prod(np.power(np.ones(len(data[0])) * 2, num_qubits)))
-            )
+            prob_data = np.zeros(int(np.prod(np.power(np.ones(len(data[0])) * 2, num_qubits))))
         else:
             prob_data = np.zeros(int(np.prod(np.power(np.array([2]), num_qubits))))
         for data_element in data:

--- a/qiskit_machine_learning/datasets/digits.py
+++ b/qiskit_machine_learning/datasets/digits.py
@@ -54,8 +54,7 @@ def digits(training_size, test_size, n, plot_data=False, one_hot=True):
         for k, key in enumerate(class_labels)
     }
     test_input = {
-        key: (sample_test[label_test == k, :])[:test_size]
-        for k, key in enumerate(class_labels)
+        key: (sample_test[label_test == k, :])[:test_size] for k, key in enumerate(class_labels)
     }
     training_feature_array, training_label_array = features_and_labels_transform(
         training_input, class_labels, one_hot

--- a/qiskit_machine_learning/datasets/gaussian.py
+++ b/qiskit_machine_learning/datasets/gaussian.py
@@ -34,22 +34,14 @@ def gaussian(training_size, test_size, n, plot_data=False, one_hot=True):
         for t_r in range(training_size + test_size):
             for feat in range(n):
                 if randomized_vector1[feat] == 0:
-                    sample_a[t_r][feat] = algorithm_globals.random.normal(
-                        -1 / 2, sigma, None
-                    )
+                    sample_a[t_r][feat] = algorithm_globals.random.normal(-1 / 2, sigma, None)
                 elif randomized_vector1[feat] == 1:
-                    sample_a[t_r][feat] = algorithm_globals.random.normal(
-                        1 / 2, sigma, None
-                    )
+                    sample_a[t_r][feat] = algorithm_globals.random.normal(1 / 2, sigma, None)
 
                 if randomized_vector2[feat] == 0:
-                    sample_b[t_r][feat] = algorithm_globals.random.normal(
-                        -1 / 2, sigma, None
-                    )
+                    sample_b[t_r][feat] = algorithm_globals.random.normal(-1 / 2, sigma, None)
                 elif randomized_vector2[feat] == 1:
-                    sample_b[t_r][feat] = algorithm_globals.random.normal(
-                        1 / 2, sigma, None
-                    )
+                    sample_b[t_r][feat] = algorithm_globals.random.normal(1 / 2, sigma, None)
 
         sample_train = [sample_a, sample_b]
         for lindex in range(training_size + test_size):
@@ -63,9 +55,7 @@ def gaussian(training_size, test_size, n, plot_data=False, one_hot=True):
             for k, key in enumerate(class_labels)
         }
         test_input = {
-            key: (sample_train[label_train == k, :])[
-                training_size : (training_size + test_size)
-            ]
+            key: (sample_train[label_train == k, :])[training_size : (training_size + test_size)]
             for k, key in enumerate(class_labels)
         }
 
@@ -158,9 +148,7 @@ def gaussian(training_size, test_size, n, plot_data=False, one_hot=True):
         for lindex in range(training_size + test_size):
             label_train[training_size + test_size + lindex] = 1
         for lindex in range(training_size + test_size):
-            label_train[
-                training_size + test_size + training_size + test_size + lindex
-            ] = 2
+            label_train[training_size + test_size + training_size + test_size + lindex] = 2
         label_train = label_train.astype(int)
         sample_train = np.reshape(sample_train, (3 * (training_size + test_size), n))
         training_input = {
@@ -168,9 +156,7 @@ def gaussian(training_size, test_size, n, plot_data=False, one_hot=True):
             for k, key in enumerate(class_labels)
         }
         test_input = {
-            key: (sample_train[label_train == k, :])[
-                training_size : (training_size + test_size)
-            ]
+            key: (sample_train[label_train == k, :])[training_size : (training_size + test_size)]
             for k, key in enumerate(class_labels)
         }
 

--- a/qiskit_machine_learning/datasets/iris.py
+++ b/qiskit_machine_learning/datasets/iris.py
@@ -53,8 +53,7 @@ def iris(training_size, test_size, n, plot_data=False, one_hot=True):
         for k, key in enumerate(class_labels)
     }
     test_input = {
-        key: (sample_test[label_test == k, :])[:test_size]
-        for k, key in enumerate(class_labels)
+        key: (sample_test[label_test == k, :])[:test_size] for k, key in enumerate(class_labels)
     }
 
     training_feature_array, training_label_array = features_and_labels_transform(

--- a/qiskit_machine_learning/datasets/wine.py
+++ b/qiskit_machine_learning/datasets/wine.py
@@ -53,8 +53,7 @@ def wine(training_size, test_size, n, plot_data=False, one_hot=True):
         for k, key in enumerate(class_labels)
     }
     test_input = {
-        key: (sample_test[label_test == k, :])[:test_size]
-        for k, key in enumerate(class_labels)
+        key: (sample_test[label_test == k, :])[:test_size] for k, key in enumerate(class_labels)
     }
 
     training_feature_array, training_label_array = features_and_labels_transform(

--- a/qiskit_machine_learning/kernels/quantum_kernel.py
+++ b/qiskit_machine_learning/kernels/quantum_kernel.py
@@ -224,8 +224,7 @@ class QuantumKernel:
         if y_vec is not None and y_vec.shape[1] != x_vec.shape[1]:
             raise ValueError(
                 "x_vec and y_vec have incompatible dimensions.\n"
-                + "x_vec has %s dimensions, but y_vec has %s."
-                % (x_vec.shape[1], y_vec.shape[1])
+                + "x_vec has %s dimensions, but y_vec has %s." % (x_vec.shape[1], y_vec.shape[1])
             )
 
         if x_vec.shape[1] != self._feature_map.num_parameters:
@@ -278,18 +277,14 @@ class QuantumKernel:
             else:  # not symmetric
                 to_be_computed_data = np.concatenate((x_vec, y_vec))
 
-            feature_map_params = ParameterVector(
-                "par_x", self._feature_map.num_parameters
-            )
+            feature_map_params = ParameterVector("par_x", self._feature_map.num_parameters)
             parameterized_circuit = self.construct_circuit(
                 feature_map_params,
                 feature_map_params,
                 measurement=measurement,
                 is_statevector_sim=is_statevector_sim,
             )
-            parameterized_circuit = self._quantum_instance.transpile(
-                parameterized_circuit
-            )[0]
+            parameterized_circuit = self._quantum_instance.transpile(parameterized_circuit)[0]
             circuits = [
                 parameterized_circuit.assign_parameters({feature_map_params: x})
                 for x in to_be_computed_data
@@ -299,9 +294,7 @@ class QuantumKernel:
 
             offset = 0 if is_symmetric else len(x_vec)
             matrix_elements = [
-                self._compute_overlap(
-                    idx, results, is_statevector_sim, measurement_basis
-                )
+                self._compute_overlap(idx, results, is_statevector_sim, measurement_basis)
                 for idx in list(zip(mus, nus + offset))
             ]
 
@@ -311,21 +304,15 @@ class QuantumKernel:
                     kernel[j, i] = kernel[i, j]
 
         else:  # not using state vector simulator
-            feature_map_params_x = ParameterVector(
-                "par_x", self._feature_map.num_parameters
-            )
-            feature_map_params_y = ParameterVector(
-                "par_y", self._feature_map.num_parameters
-            )
+            feature_map_params_x = ParameterVector("par_x", self._feature_map.num_parameters)
+            feature_map_params_y = ParameterVector("par_y", self._feature_map.num_parameters)
             parameterized_circuit = self.construct_circuit(
                 feature_map_params_x,
                 feature_map_params_y,
                 measurement=measurement,
                 is_statevector_sim=is_statevector_sim,
             )
-            parameterized_circuit = self._quantum_instance.transpile(
-                parameterized_circuit
-            )[0]
+            parameterized_circuit = self._quantum_instance.transpile(parameterized_circuit)[0]
 
             for idx in range(0, len(mus), self._batch_size):
                 to_be_computed_data_pair = []
@@ -349,9 +336,7 @@ class QuantumKernel:
                 results = self._quantum_instance.execute(circuits)
 
                 matrix_elements = [
-                    self._compute_overlap(
-                        circuit, results, is_statevector_sim, measurement_basis
-                    )
+                    self._compute_overlap(circuit, results, is_statevector_sim, measurement_basis)
                     for circuit in range(len(circuits))
                 ]
 

--- a/qiskit_machine_learning/neural_networks/circuit_qnn.py
+++ b/qiskit_machine_learning/neural_networks/circuit_qnn.py
@@ -101,9 +101,7 @@ class CircuitQNN(SamplingNeuralNetwork):
         )
 
         # prepare sampler
-        self._sampler = CircuitSampler(
-            self._quantum_instance, param_qobj=False, caching="all"
-        )
+        self._sampler = CircuitSampler(self._quantum_instance, param_qobj=False, caching="all")
 
         self._original_circuit = circuit
         # use given gradient or default
@@ -121,17 +119,11 @@ class CircuitQNN(SamplingNeuralNetwork):
                 params = self._input_params + self._weight_params
             else:
                 params = self._weight_params
-            self._gradient_circuit = self._gradient.convert(
-                StateFn(grad_circuit), params
-            )
+            self._gradient_circuit = self._gradient.convert(StateFn(grad_circuit), params)
         except (ValueError, TypeError, OpflowError, QiskitError):
-            logger.warning(
-                "Cannot compute gradient operator! Continuing without gradients!"
-            )
+            logger.warning("Cannot compute gradient operator! Continuing without gradients!")
 
-    def _compute_output_shape(
-        self, interpret, output_shape, sampling
-    ) -> Tuple[int, ...]:
+    def _compute_output_shape(self, interpret, output_shape, sampling) -> Tuple[int, ...]:
         """Validate and compute the output shape."""
 
         # this definition is required by mypy
@@ -210,17 +202,13 @@ class CircuitQNN(SamplingNeuralNetwork):
         output _shape does not have to be set and is inferred from the interpret function.
         Otherwise, the output_shape needs to be given."""
         self._interpret = interpret if interpret else lambda x: x
-        self._output_shape = self._compute_output_shape(
-            interpret, output_shape, self._sampling
-        )
+        self._output_shape = self._compute_output_shape(interpret, output_shape, self._sampling)
 
     def _sample(
         self, input_data: Optional[np.ndarray], weights: Optional[np.ndarray]
     ) -> np.ndarray:
         if self._quantum_instance.is_statevector:
-            raise QiskitMachineLearningError(
-                "Sampling does not work with statevector simulator!"
-            )
+            raise QiskitMachineLearningError("Sampling does not work with statevector simulator!")
 
         # evaluate operator
         orig_memory = self._quantum_instance.backend_options.get("memory")
@@ -231,14 +219,10 @@ class CircuitQNN(SamplingNeuralNetwork):
         rows = input_data.shape[0]
         for i in range(rows):
             param_values = {
-                input_param: input_data[i, j]
-                for j, input_param in enumerate(self._input_params)
+                input_param: input_data[i, j] for j, input_param in enumerate(self._input_params)
             }
             param_values.update(
-                {
-                    weight_param: weights[j]
-                    for j, weight_param in enumerate(self._weight_params)
-                }
+                {weight_param: weights[j] for j, weight_param in enumerate(self._weight_params)}
             )
             circuits.append(self._circuit.bind_parameters(param_values))
 
@@ -263,14 +247,10 @@ class CircuitQNN(SamplingNeuralNetwork):
         rows = input_data.shape[0]
         for i in range(rows):
             param_values = {
-                input_param: input_data[i, j]
-                for j, input_param in enumerate(self._input_params)
+                input_param: input_data[i, j] for j, input_param in enumerate(self._input_params)
             }
             param_values.update(
-                {
-                    weight_param: weights[j]
-                    for j, weight_param in enumerate(self._weight_params)
-                }
+                {weight_param: weights[j] for j, weight_param in enumerate(self._weight_params)}
             )
             circuits.append(self._circuit.bind_parameters(param_values))
 
@@ -321,14 +301,10 @@ class CircuitQNN(SamplingNeuralNetwork):
 
         for row in range(rows):
             param_values = {
-                input_param: input_data[row, j]
-                for j, input_param in enumerate(self._input_params)
+                input_param: input_data[row, j] for j, input_param in enumerate(self._input_params)
             }
             param_values.update(
-                {
-                    weight_param: weights[j]
-                    for j, weight_param in enumerate(self._weight_params)
-                }
+                {weight_param: weights[j] for j, weight_param in enumerate(self._weight_params)}
             )
 
             # TODO: additional "bind_parameters" should not be necessary,

--- a/qiskit_machine_learning/neural_networks/neural_network.py
+++ b/qiskit_machine_learning/neural_networks/neural_network.py
@@ -45,9 +45,7 @@ class NeuralNetwork(ABC):
             QiskitMachineLearningError: Invalid parameter values.
         """
         if num_inputs < 0:
-            raise QiskitMachineLearningError(
-                f"Number of inputs cannot be negative: {num_inputs}!"
-            )
+            raise QiskitMachineLearningError(f"Number of inputs cannot be negative: {num_inputs}!")
         self._num_inputs = num_inputs
 
         if num_weights < 0:
@@ -139,9 +137,7 @@ class NeuralNetwork(ABC):
         self, output_data: np.ndarray, original_shape: Tuple[int, ...]
     ) -> np.ndarray:
         if original_shape and len(original_shape) >= 2:
-            output_data = output_data.reshape(
-                (*original_shape[:-1], *self._output_shape)
-            )
+            output_data = output_data.reshape((*original_shape[:-1], *self._output_shape))
 
         return output_data
 
@@ -192,10 +188,7 @@ class NeuralNetwork(ABC):
         self,
         input_data: Optional[Union[List[float], np.ndarray, float]],
         weights: Optional[Union[List[float], np.ndarray, float]],
-    ) -> Tuple[
-        Optional[Union[np.ndarray, SparseArray]],
-        Optional[Union[np.ndarray, SparseArray]],
-    ]:
+    ) -> Tuple[Optional[Union[np.ndarray, SparseArray]], Optional[Union[np.ndarray, SparseArray]],]:
         """Backward pass of the network.
 
         Args:
@@ -221,8 +214,5 @@ class NeuralNetwork(ABC):
     @abstractmethod
     def _backward(
         self, input_data: Optional[np.ndarray], weights: Optional[np.ndarray]
-    ) -> Tuple[
-        Optional[Union[np.ndarray, SparseArray]],
-        Optional[Union[np.ndarray, SparseArray]],
-    ]:
+    ) -> Tuple[Optional[Union[np.ndarray, SparseArray]], Optional[Union[np.ndarray, SparseArray]],]:
         raise NotImplementedError

--- a/qiskit_machine_learning/neural_networks/opflow_qnn.py
+++ b/qiskit_machine_learning/neural_networks/opflow_qnn.py
@@ -100,9 +100,7 @@ class OpflowQNN(NeuralNetwork):
 
             self._gradient_operator = gradient.convert(self._operator, params)
         except (ValueError, TypeError, OpflowError, QiskitError):
-            logger.warning(
-                "Cannot compute gradient operator! Continuing without gradients!"
-            )
+            logger.warning("Cannot compute gradient operator! Continuing without gradients!")
 
     def _get_output_shape_from_op(self, op: OperatorBase) -> Tuple[int, ...]:
         """Determines the output shape of a given operator."""
@@ -148,14 +146,9 @@ class OpflowQNN(NeuralNetwork):
     ) -> Union[np.ndarray, SparseArray]:
         # combine parameter dictionary
         # take i-th column as values for the i-th param in a batch
-        param_values = {
-            p: input_data[:, i].tolist() for i, p in enumerate(self._input_params)
-        }
+        param_values = {p: input_data[:, i].tolist() for i, p in enumerate(self._input_params)}
         param_values.update(
-            {
-                p: [weights[i]] * input_data.shape[0]
-                for i, p in enumerate(self._weight_params)
-            }
+            {p: [weights[i]] * input_data.shape[0] for i, p in enumerate(self._weight_params)}
         )
 
         # evaluate operator
@@ -170,10 +163,7 @@ class OpflowQNN(NeuralNetwork):
 
     def _backward(
         self, input_data: Optional[np.ndarray], weights: Optional[np.ndarray]
-    ) -> Tuple[
-        Optional[Union[np.ndarray, SparseArray]],
-        Optional[Union[np.ndarray, SparseArray]],
-    ]:
+    ) -> Tuple[Optional[Union[np.ndarray, SparseArray]], Optional[Union[np.ndarray, SparseArray]],]:
 
         # check whether gradient circuit could be constructed
         if self._gradient_operator is None:
@@ -190,18 +180,12 @@ class OpflowQNN(NeuralNetwork):
 
         for row in range(batch_size):
             # take i-th column as values for the i-th param in a batch
-            param_values = {
-                p: input_data[row, j] for j, p in enumerate(self._input_params)
-            }
-            param_values.update(
-                {p: weights[j] for j, p in enumerate(self._weight_params)}
-            )
+            param_values = {p: input_data[row, j] for j, p in enumerate(self._input_params)}
+            param_values.update({p: weights[j] for j, p in enumerate(self._weight_params)})
 
             # evaluate gradient over all parameters
             if self._circuit_sampler:
-                grad = self._circuit_sampler.convert(
-                    self._gradient_operator, param_values
-                )
+                grad = self._circuit_sampler.convert(self._gradient_operator, param_values)
                 # TODO: this should not be necessary and is a bug!
                 grad = grad.bind_parameters(param_values)
                 grad = np.real(grad.eval())

--- a/qiskit_machine_learning/neural_networks/sampling_neural_network.py
+++ b/qiskit_machine_learning/neural_networks/sampling_neural_network.py
@@ -74,10 +74,7 @@ class SamplingNeuralNetwork(NeuralNetwork):
 
     def _backward(
         self, input_data: Optional[np.ndarray], weights: Optional[np.ndarray]
-    ) -> Tuple[
-        Optional[Union[np.ndarray, SparseArray]],
-        Optional[Union[np.ndarray, SparseArray]],
-    ]:
+    ) -> Tuple[Optional[Union[np.ndarray, SparseArray]], Optional[Union[np.ndarray, SparseArray]],]:
         """Backward pass of the network. Returns (None, None) in case of samples and the
         corresponding here probability gradients otherwise.
         """

--- a/qiskit_machine_learning/neural_networks/two_layer_qnn.py
+++ b/qiskit_machine_learning/neural_networks/two_layer_qnn.py
@@ -67,26 +67,20 @@ class TwoLayerQNN(OpflowQNN):
             num_qubits_ = num_qubits
             if feature_map:
                 if feature_map.num_qubits != num_qubits:
-                    raise QiskitMachineLearningError(
-                        "Incompatible num_qubits and feature_map!"
-                    )
+                    raise QiskitMachineLearningError("Incompatible num_qubits and feature_map!")
                 feature_map_ = feature_map
             else:
                 feature_map_ = ZZFeatureMap(num_qubits)
             if ansatz:
                 if ansatz.num_qubits != num_qubits:
-                    raise QiskitMachineLearningError(
-                        "Incompatible num_qubits and ansatz!"
-                    )
+                    raise QiskitMachineLearningError("Incompatible num_qubits and ansatz!")
                 ansatz_ = ansatz
             else:
                 ansatz_ = RealAmplitudes(num_qubits)
         else:
             if feature_map and ansatz:
                 if feature_map.num_qubits != ansatz.num_qubits:
-                    raise QiskitMachineLearningError(
-                        "Incompatible feature_map and ansatz!"
-                    )
+                    raise QiskitMachineLearningError("Incompatible feature_map and ansatz!")
                 feature_map_ = feature_map
                 ansatz_ = ansatz
                 num_qubits_ = feature_map.num_qubits
@@ -118,9 +112,7 @@ class TwoLayerQNN(OpflowQNN):
         # combine all to operator
         operator = ~StateFn(self.observable) @ StateFn(self._circuit)
 
-        super().__init__(
-            operator, input_params, weight_params, quantum_instance=quantum_instance
-        )
+        super().__init__(operator, input_params, weight_params, quantum_instance=quantum_instance)
 
     @property
     def feature_map(self) -> QuantumCircuit:

--- a/qiskit_machine_learning/utils/loss_functions/loss_functions.py
+++ b/qiskit_machine_learning/utils/loss_functions/loss_functions.py
@@ -42,8 +42,7 @@ class Loss(ABC):
         target = np.array(target)
         if predict.shape != target.shape:
             raise QiskitMachineLearningError(
-                f"Shapes don't match, predict: {predict.shape}, "
-                f"target: {target.shape}!"
+                f"Shapes don't match, predict: {predict.shape}, " f"target: {target.shape}!"
             )
         return predict, target
 
@@ -59,9 +58,7 @@ class L1Loss(Loss):
         elif len(predict.shape) <= 1:
             return np.linalg.norm(predict - target, ord=1)
         elif len(predict.shape) > 1:
-            return np.linalg.norm(
-                predict - target, ord=1, axis=tuple(range(1, len(predict.shape)))
-            )
+            return np.linalg.norm(predict - target, ord=1, axis=tuple(range(1, len(predict.shape))))
         else:
             raise QiskitMachineLearningError(f"Invalid shape {predict.shape}!")
 

--- a/test/algorithms/classifiers/test_neural_network_classifier.py
+++ b/test/algorithms/classifiers/test_neural_network_classifier.py
@@ -208,9 +208,7 @@ class TestNeuralNetworkClassifier(QiskitMachineLearningTestCase):
         )
 
         # construct classifier - note: CrossEntropy requires eval_probabilities=True!
-        classifier = NeuralNetworkClassifier(
-            qnn, optimizer=optimizer, loss=loss, one_hot=True
-        )
+        classifier = NeuralNetworkClassifier(qnn, optimizer=optimizer, loss=loss, one_hot=True)
 
         # construct data
         num_samples = 5

--- a/test/algorithms/classifiers/test_qsvc.py
+++ b/test/algorithms/classifiers/test_qsvc.py
@@ -53,9 +53,7 @@ class TestQSVC(QiskitMachineLearningTestCase):
         )
         self.label_train = np.asarray([0, 0, 1, 1])
 
-        self.sample_test = np.asarray(
-            [[2.199114860, 5.15221195], [0.50265482, 0.06283185]]
-        )
+        self.sample_test = np.asarray([[2.199114860, 5.15221195], [0.50265482, 0.06283185]])
         self.label_test = np.asarray([0, 1])
 
     def test_qsvc(self):

--- a/test/algorithms/distribution_learners/qgan/test_qgan.py
+++ b/test/algorithms/distribution_learners/qgan/test_qgan.py
@@ -45,9 +45,7 @@ class TestQGAN(QiskitMachineLearningTestCase):
         # Load data samples from log-normal distribution with mean=1 and standard deviation=1
         m_u = 1
         sigma = 1
-        self._real_data = algorithm_globals.random.lognormal(
-            mean=m_u, sigma=sigma, size=n_v
-        )
+        self._real_data = algorithm_globals.random.lognormal(mean=m_u, sigma=sigma, size=n_v)
         # Set upper and lower data values as list of k
         # min/max data values [[min_0,max_0],...,[min_k-1,max_k-1]]
         self._bounds = [0.0, 3.0]
@@ -94,12 +92,8 @@ class TestQGAN(QiskitMachineLearningTestCase):
         """Test sample generation."""
         self.qgan.set_generator(generator_circuit=self.generator_circuit)
 
-        _, weights_statevector = self.qgan._generator.get_output(
-            self.qi_statevector, shots=100
-        )
-        samples_qasm, weights_qasm = self.qgan._generator.get_output(
-            self.qi_qasm, shots=100
-        )
+        _, weights_statevector = self.qgan._generator.get_output(self.qi_statevector, shots=100)
+        samples_qasm, weights_qasm = self.qgan._generator.get_output(self.qi_qasm, shots=100)
         samples_qasm, weights_qasm = zip(*sorted(zip(samples_qasm, weights_qasm)))
         for i, weight_q in enumerate(weights_qasm):
             self.assertAlmostEqual(weight_q, weights_statevector[i], delta=0.1)
@@ -112,9 +106,7 @@ class TestQGAN(QiskitMachineLearningTestCase):
         )
         trained_statevector = self.qgan.run(self.qi_statevector)
         trained_qasm = self.qgan.run(self.qi_qasm)
-        self.assertAlmostEqual(
-            trained_qasm["rel_entr"], trained_statevector["rel_entr"], delta=0.1
-        )
+        self.assertAlmostEqual(trained_qasm["rel_entr"], trained_statevector["rel_entr"], delta=0.1)
 
     def test_qgan_training_cobyla(self):
         """Test QGAN training."""
@@ -124,9 +116,7 @@ class TestQGAN(QiskitMachineLearningTestCase):
         )
         trained_statevector = self.qgan.run(self.qi_statevector)
         trained_qasm = self.qgan.run(self.qi_qasm)
-        self.assertAlmostEqual(
-            trained_qasm["rel_entr"], trained_statevector["rel_entr"], delta=0.1
-        )
+        self.assertAlmostEqual(trained_qasm["rel_entr"], trained_statevector["rel_entr"], delta=0.1)
 
     def test_qgan_training(self):
         """Test QGAN training."""
@@ -136,9 +126,7 @@ class TestQGAN(QiskitMachineLearningTestCase):
 
         trained_statevector = self.qgan.run(self.qi_statevector)
         trained_qasm = self.qgan.run(self.qi_qasm)
-        self.assertAlmostEqual(
-            trained_qasm["rel_entr"], trained_statevector["rel_entr"], delta=0.1
-        )
+        self.assertAlmostEqual(trained_qasm["rel_entr"], trained_statevector["rel_entr"], delta=0.1)
 
     @requires_extra_library
     def test_qgan_training_run_algo_torch(self):
@@ -174,9 +162,7 @@ class TestQGAN(QiskitMachineLearningTestCase):
                 seed_transpiler=algorithm_globals.random_seed,
             )
         )
-        self.assertAlmostEqual(
-            trained_qasm["rel_entr"], trained_statevector["rel_entr"], delta=0.1
-        )
+        self.assertAlmostEqual(trained_qasm["rel_entr"], trained_statevector["rel_entr"], delta=0.1)
 
     @requires_extra_library
     def test_qgan_training_run_algo_torch_multivariate(self):
@@ -219,9 +205,7 @@ class TestQGAN(QiskitMachineLearningTestCase):
                 seed_transpiler=algorithm_globals.random_seed,
             )
         )
-        self.assertAlmostEqual(
-            trained_qasm["rel_entr"], trained_statevector["rel_entr"], delta=0.1
-        )
+        self.assertAlmostEqual(trained_qasm["rel_entr"], trained_statevector["rel_entr"], delta=0.1)
 
     def test_qgan_training_run_algo_numpy(self):
         """Test QGAN training using a NumPy discriminator."""
@@ -256,9 +240,7 @@ class TestQGAN(QiskitMachineLearningTestCase):
                 seed_transpiler=algorithm_globals.random_seed,
             )
         )
-        self.assertAlmostEqual(
-            trained_qasm["rel_entr"], trained_statevector["rel_entr"], delta=0.1
-        )
+        self.assertAlmostEqual(trained_qasm["rel_entr"], trained_statevector["rel_entr"], delta=0.1)
 
     def test_qgan_save_model(self):
         """Test the QGAN functionality to store the current model."""
@@ -294,9 +276,7 @@ class TestQGAN(QiskitMachineLearningTestCase):
                     seed_transpiler=algorithm_globals.random_seed,
                 )
             )
-        self.assertAlmostEqual(
-            trained_qasm["rel_entr"], trained_statevector["rel_entr"], delta=0.1
-        )
+        self.assertAlmostEqual(trained_qasm["rel_entr"], trained_statevector["rel_entr"], delta=0.1)
 
     def test_qgan_training_run_algo_numpy_multivariate(self):
         """Test QGAN training using a NumPy discriminator, for multivariate distributions."""
@@ -338,9 +318,7 @@ class TestQGAN(QiskitMachineLearningTestCase):
                 seed_transpiler=algorithm_globals.random_seed,
             )
         )
-        self.assertAlmostEqual(
-            trained_qasm["rel_entr"], trained_statevector["rel_entr"], delta=0.1
-        )
+        self.assertAlmostEqual(trained_qasm["rel_entr"], trained_statevector["rel_entr"], delta=0.1)
 
     @data("qasm", "sv")
     def test_qgan_training_analytic_gradients(self, backend: str):
@@ -355,13 +333,9 @@ class TestQGAN(QiskitMachineLearningTestCase):
             q_inst = self.qi_statevector
         self.qgan.set_generator(self.generator_circuit)
         numeric_results = self.qgan.run(q_inst)
-        self.qgan.set_generator(
-            self.generator_circuit, generator_gradient=Gradient("param_shift")
-        )
+        self.qgan.set_generator(self.generator_circuit, generator_gradient=Gradient("param_shift"))
         analytic_results = self.qgan.run(q_inst)
-        self.assertAlmostEqual(
-            numeric_results["rel_entr"], analytic_results["rel_entr"], delta=0.1
-        )
+        self.assertAlmostEqual(numeric_results["rel_entr"], analytic_results["rel_entr"], delta=0.1)
 
 
 if __name__ == "__main__":

--- a/test/algorithms/regressors/test_qsvr.py
+++ b/test/algorithms/regressors/test_qsvr.py
@@ -52,9 +52,7 @@ class TestQSVR(QiskitMachineLearningTestCase):
         )
         self.label_train = np.asarray([0, 0, 1, 1])
 
-        self.sample_test = np.asarray(
-            [[2.199114860, 5.15221195], [0.50265482, 0.06283185]]
-        )
+        self.sample_test = np.asarray([[2.199114860, 5.15221195], [0.50265482, 0.06283185]])
         self.label_test = np.asarray([0, 1])
 
     def test_qsvr(self):

--- a/test/connectors/test_torch_connector.py
+++ b/test/connectors/test_torch_connector.py
@@ -57,9 +57,7 @@ class TestTorchConnector(QiskitMachineLearningTestCase):
         self.sv_quantum_instance = QuantumInstance(StatevectorSimulator())
         self.qasm_quantum_instance = QuantumInstance(AerSimulator(), shots=100)
 
-    def validate_output_shape(
-        self, model: TorchConnector, test_data: List[Tensor]
-    ) -> None:
+    def validate_output_shape(self, model: TorchConnector, test_data: List[Tensor]) -> None:
         """Creates a Linear PyTorch module with the same in/out dimensions as the given model,
         applies the list of test input data to both, and asserts that they have the same
         output shape.
@@ -84,9 +82,7 @@ class TestTorchConnector(QiskitMachineLearningTestCase):
         # create benchmark model
         in_dim = model.neural_network.num_inputs
         if len(model.neural_network.output_shape) != 1:
-            raise QiskitMachineLearningError(
-                "Function only works for one dimensional output"
-            )
+            raise QiskitMachineLearningError("Function only works for one dimensional output")
         out_dim = model.neural_network.output_shape[0]
         linear = Linear(in_dim, out_dim)
 
@@ -126,12 +122,8 @@ class TestTorchConnector(QiskitMachineLearningTestCase):
         # test autograd
         func = TorchConnector._TorchNNFunction.apply  # (input, weights, qnn)
         input_data = (
-            torch.randn(
-                model.neural_network.num_inputs, dtype=torch.double, requires_grad=True
-            ),
-            torch.randn(
-                model.neural_network.num_weights, dtype=torch.double, requires_grad=True
-            ),
+            torch.randn(model.neural_network.num_inputs, dtype=torch.double, requires_grad=True),
+            torch.randn(model.neural_network.num_weights, dtype=torch.double, requires_grad=True),
             model.neural_network,
             False,
         )
@@ -482,9 +474,7 @@ class TestTorchConnector(QiskitMachineLearningTestCase):
         x = np.random.rand(num_samples, num_inputs)
 
         # set up QNN
-        qnn = TwoLayerQNN(
-            num_qubits=num_inputs, quantum_instance=self.sv_quantum_instance
-        )
+        qnn = TwoLayerQNN(num_qubits=num_inputs, quantum_instance=self.sv_quantum_instance)
 
         # set up PyTorch module
         initial_weights = np.random.rand(qnn.num_weights)

--- a/test/datasets/test_digits.py
+++ b/test/datasets/test_digits.py
@@ -33,9 +33,7 @@ class TestDigits(QiskitMachineLearningTestCase):
             training_size=20, test_size=10, n=2, plot_data=False
         )
 
-        np.testing.assert_almost_equal(
-            ref_data["training_features"], training_features, 4
-        )
+        np.testing.assert_almost_equal(ref_data["training_features"], training_features, 4)
         np.testing.assert_almost_equal(ref_data["training_labels"], training_labels, 4)
 
         np.testing.assert_almost_equal(ref_data["test_features"], test_features, 3)

--- a/test/datasets/test_gaussian.py
+++ b/test/datasets/test_gaussian.py
@@ -30,9 +30,7 @@ class TestGaussian(QiskitMachineLearningTestCase):
         np.testing.assert_array_equal(training_features.shape, (40, 2))
         np.testing.assert_array_equal(training_labels.shape, (40, 2))
 
-        np.testing.assert_array_equal(
-            np.sum(training_labels, axis=0), np.array([20, 20])
-        )
+        np.testing.assert_array_equal(np.sum(training_labels, axis=0), np.array([20, 20]))
         np.testing.assert_array_equal(np.sum(training_labels, axis=1), np.ones(40))
 
         np.testing.assert_array_equal(test_features.shape, (20, 2))

--- a/test/kernels/test_qkernel.py
+++ b/test/kernels/test_qkernel.py
@@ -54,9 +54,7 @@ class TestQuantumKernelClassify(QiskitMachineLearningTestCase):
         )
         self.label_train = np.asarray([0, 0, 1, 1])
 
-        self.sample_test = np.asarray(
-            [[2.199114860, 5.15221195], [0.50265482, 0.06283185]]
-        )
+        self.sample_test = np.asarray([[2.199114860, 5.15221195], [0.50265482, 0.06283185]])
         self.label_test = np.asarray([0, 1])
 
     def test_callable(self):
@@ -126,9 +124,7 @@ class TestQuantumKernelEvaluate(QiskitMachineLearningTestCase):
             ]
         )
 
-        self.sample_test = np.asarray(
-            [[3.83274304, 2.45044227], [3.89557489, 0.31415927]]
-        )
+        self.sample_test = np.asarray([[3.83274304, 2.45044227], [3.89557489, 0.31415927]])
 
         self.sample_feature_dim = np.asarray([[1, 2, 3], [4, 5, 6]])
         self.sample_more_dim = np.asarray([[[0, 0], [1, 1]]])
@@ -192,9 +188,7 @@ class TestQuantumKernelEvaluate(QiskitMachineLearningTestCase):
 
     def test_qasm_symmetric(self):
         """Test symmetric matrix evaluation using qasm simulator"""
-        qkclass = QuantumKernel(
-            feature_map=self.feature_map, quantum_instance=self.qasm_simulator
-        )
+        qkclass = QuantumKernel(feature_map=self.feature_map, quantum_instance=self.qasm_simulator)
 
         kernel = qkclass.evaluate(x_vec=self.sample_train)
 
@@ -202,9 +196,7 @@ class TestQuantumKernelEvaluate(QiskitMachineLearningTestCase):
 
     def test_qasm_unsymmetric(self):
         """Test unsymmetric matrix evaluation using qasm simulator"""
-        qkclass = QuantumKernel(
-            feature_map=self.feature_map, quantum_instance=self.qasm_simulator
-        )
+        qkclass = QuantumKernel(feature_map=self.feature_map, quantum_instance=self.qasm_simulator)
 
         kernel = qkclass.evaluate(x_vec=self.sample_train, y_vec=self.sample_test)
 
@@ -218,9 +210,7 @@ class TestQuantumKernelEvaluate(QiskitMachineLearningTestCase):
 
         kernel = qkclass.evaluate(x_vec=self.sample_train)
 
-        np.testing.assert_allclose(
-            kernel, self.ref_kernel_train["statevector"], rtol=1e-4
-        )
+        np.testing.assert_allclose(kernel, self.ref_kernel_train["statevector"], rtol=1e-4)
 
     def test_sv_unsymmetric(self):
         """Test unsymmetric matrix evaluation using state vector simulator"""
@@ -230,9 +220,7 @@ class TestQuantumKernelEvaluate(QiskitMachineLearningTestCase):
 
         kernel = qkclass.evaluate(x_vec=self.sample_train, y_vec=self.sample_test)
 
-        np.testing.assert_allclose(
-            kernel, self.ref_kernel_test["statevector"], rtol=1e-4
-        )
+        np.testing.assert_allclose(kernel, self.ref_kernel_test["statevector"], rtol=1e-4)
 
     def test_qasm_nopsd(self):
         """Test symmetric matrix qasm sample no positive semi-definite enforcement"""
@@ -244,21 +232,15 @@ class TestQuantumKernelEvaluate(QiskitMachineLearningTestCase):
 
         kernel = qkclass.evaluate(x_vec=self.sample_train)
 
-        np.testing.assert_allclose(
-            kernel, self.ref_kernel_train["qasm_sample"], rtol=1e-4
-        )
+        np.testing.assert_allclose(kernel, self.ref_kernel_train["qasm_sample"], rtol=1e-4)
 
     def test_qasm_psd(self):
         """Test symmetric matrix positive semi-definite enforcement qasm sample"""
-        qkclass = QuantumKernel(
-            feature_map=self.feature_map, quantum_instance=self.qasm_sample
-        )
+        qkclass = QuantumKernel(feature_map=self.feature_map, quantum_instance=self.qasm_sample)
 
         kernel = qkclass.evaluate(x_vec=self.sample_train)
 
-        np.testing.assert_allclose(
-            kernel, self.ref_kernel_train["qasm_sample_psd"], rtol=1e-4
-        )
+        np.testing.assert_allclose(kernel, self.ref_kernel_train["qasm_sample_psd"], rtol=1e-4)
 
     def test_x_one_dim(self):
         """Test one x_vec dimension"""
@@ -288,9 +270,7 @@ class TestQuantumKernelEvaluate(QiskitMachineLearningTestCase):
 
         kernel = qkclass.evaluate(x_vec=self.sample_train[0], y_vec=self.sample_test[0])
 
-        np.testing.assert_allclose(
-            kernel, self.ref_kernel_test["one_xy_dim"], rtol=1e-4
-        )
+        np.testing.assert_allclose(kernel, self.ref_kernel_test["one_xy_dim"], rtol=1e-4)
 
     def test_no_backend(self):
         """Test no backend provided"""
@@ -301,27 +281,21 @@ class TestQuantumKernelEvaluate(QiskitMachineLearningTestCase):
 
     def test_x_more_dim(self):
         """Test incorrect x_vec dimension"""
-        qkclass = QuantumKernel(
-            feature_map=self.feature_map, quantum_instance=self.qasm_simulator
-        )
+        qkclass = QuantumKernel(feature_map=self.feature_map, quantum_instance=self.qasm_simulator)
 
         with self.assertRaises(ValueError):
             _ = qkclass.evaluate(x_vec=self.sample_more_dim)
 
     def test_y_more_dim(self):
         """Test incorrect y_vec dimension"""
-        qkclass = QuantumKernel(
-            feature_map=self.feature_map, quantum_instance=self.qasm_simulator
-        )
+        qkclass = QuantumKernel(feature_map=self.feature_map, quantum_instance=self.qasm_simulator)
 
         with self.assertRaises(ValueError):
             _ = qkclass.evaluate(x_vec=self.sample_train, y_vec=self.sample_more_dim)
 
     def test_y_feature_dim(self):
         """Test incorrect y_vec feature dimension"""
-        qkclass = QuantumKernel(
-            feature_map=self.feature_map, quantum_instance=self.qasm_simulator
-        )
+        qkclass = QuantumKernel(feature_map=self.feature_map, quantum_instance=self.qasm_simulator)
 
         with self.assertRaises(ValueError):
             _ = qkclass.evaluate(x_vec=self.sample_train, y_vec=self.sample_feature_dim)

--- a/test/machine_learning_test_case.py
+++ b/test/machine_learning_test_case.py
@@ -79,9 +79,8 @@ class QiskitMachineLearningTestCase(unittest.TestCase, ABC):
         # is set.
         if os.getenv("LOG_LEVEL"):
             # Set up formatter.
-            log_fmt = (
-                "{}.%(funcName)s:%(levelname)s:%(asctime)s:"
-                " %(message)s".format(cls.__name__)
+            log_fmt = "{}.%(funcName)s:%(levelname)s:%(asctime)s:" " %(message)s".format(
+                cls.__name__
             )
             formatter = logging.Formatter(log_fmt)
 

--- a/test/neural_networks/test_circuit_qnn.py
+++ b/test/neural_networks/test_circuit_qnn.py
@@ -199,9 +199,7 @@ class TestCircuitQNN(QiskitMachineLearningTestCase):
                 self.assertIsNone(input_grad)
                 self.assertIsNone(weights_grad)
             else:
-                self.assertEqual(
-                    input_grad.shape, (batch_size, *qnn.output_shape, qnn.num_inputs)
-                )
+                self.assertEqual(input_grad.shape, (batch_size, *qnn.output_shape, qnn.num_inputs))
                 self.assertEqual(
                     weights_grad.shape, (batch_size, *qnn.output_shape, qnn.num_weights)
                 )
@@ -252,9 +250,9 @@ class TestCircuitQNN(QiskitMachineLearningTestCase):
                 diff = input_grad_ - grad
             else:
                 grad = (f_1 - f_2) / (2 * eps)
-                input_grad_ = input_grad.reshape((batch_size, -1, qnn.num_inputs))[
-                    :, :, k
-                ].reshape(grad.shape)
+                input_grad_ = input_grad.reshape((batch_size, -1, qnn.num_inputs))[:, :, k].reshape(
+                    grad.shape
+                )
                 diff = input_grad_ - grad
             self.assertAlmostEqual(np.max(np.abs(diff)), 0.0, places=3)
 

--- a/test/neural_networks/test_neural_network.py
+++ b/test/neural_networks/test_neural_network.py
@@ -108,9 +108,7 @@ class TestNeuralNetwork(QiskitMachineLearningTestCase):
         batch_size = self._get_batch_size(input_data)
         network = _NeuralNetwork(*config)
 
-        input_grad, weights_grad = network.backward(
-            input_data, np.zeros(network.num_weights)
-        )
+        input_grad, weights_grad = network.backward(input_data, np.zeros(network.num_weights))
 
         if network.num_inputs > 0:
             self.assertEqual(

--- a/test/neural_networks/test_opflow_qnn.py
+++ b/test/neural_networks/test_opflow_qnn.py
@@ -40,9 +40,7 @@ class TestOpflowQNN(QiskitMachineLearningTestCase):
         self.sv_quantum_instance = QuantumInstance(StatevectorSimulator())
         self.qasm_quantum_instance = QuantumInstance(AerSimulator(shots=100))
 
-    def validate_output_shape(
-        self, qnn: OpflowQNN, test_data: List[np.ndarray]
-    ) -> None:
+    def validate_output_shape(self, qnn: OpflowQNN, test_data: List[np.ndarray]) -> None:
         """
         Asserts that the opflow qnn returns results of the correct output shape.
 

--- a/test/neural_networks/test_two_layer_qnn.py
+++ b/test/neural_networks/test_two_layer_qnn.py
@@ -111,15 +111,11 @@ class TestTwoLayerQNN(QiskitMachineLearningTestCase):
         # test backward pass
         result = qnn.backward(input_data, weights)
         if qnn.input_gradients:
-            self.assertEqual(
-                result[0].shape, (batch_size, *qnn.output_shape, qnn.num_inputs)
-            )
+            self.assertEqual(result[0].shape, (batch_size, *qnn.output_shape, qnn.num_inputs))
         else:
             self.assertIsNone(result[0])
 
-        self.assertEqual(
-            result[1].shape, (batch_size, *qnn.output_shape, qnn.num_weights)
-        )
+        self.assertEqual(result[1].shape, (batch_size, *qnn.output_shape, qnn.num_weights))
 
 
 if __name__ == "__main__":

--- a/tools/check_copyright.py
+++ b/tools/check_copyright.py
@@ -32,9 +32,7 @@ class CopyrightChecker:
 
     @staticmethod
     def _exception_to_string(excp: Exception) -> str:
-        stack = traceback.extract_stack()[:-3] + traceback.extract_tb(
-            excp.__traceback__
-        )
+        stack = traceback.extract_stack()[:-3] + traceback.extract_tb(excp.__traceback__)
         pretty = traceback.format_list(stack)
         return "".join(pretty) + "\n  {} {}".format(excp.__class__, excp)
 
@@ -53,9 +51,7 @@ class CopyrightChecker:
         year = CopyrightChecker._get_year_from_date(out_str)
         return year, err_str
 
-    def _process_file_last_year(
-        self, relative_path: str
-    ) -> Tuple[int, Union[None, str]]:
+    def _process_file_last_year(self, relative_path: str) -> Tuple[int, Union[None, str]]:
         # construct minimal environment
         env = {}
         for k in ["SYSTEMROOT", "PATH"]:
@@ -195,9 +191,7 @@ def check_path(path):
 
 if __name__ == "__main__":
     PARSER = argparse.ArgumentParser(description="Check Copyright Tool")
-    PARSER.add_argument(
-        "-path", type=check_path, metavar="path", help="Root path of project."
-    )
+    PARSER.add_argument("-path", type=check_path, metavar="path", help="Root path of project.")
 
     ARGS = PARSER.parse_args()
     if not ARGS.path:
@@ -206,10 +200,6 @@ if __name__ == "__main__":
     ARGS.path = os.path.abspath(os.path.realpath(os.path.expanduser(ARGS.path)))
     INVALID_UTF8, INVALID_YEAR, HAS_HEADER = CopyrightChecker(ARGS.path).check()
     print("{} files have utf8 headers.".format(INVALID_UTF8))
-    print(
-        "{} of {} files with copyright header have wrong years.".format(
-            INVALID_YEAR, HAS_HEADER
-        )
-    )
+    print("{} of {} files with copyright header have wrong years.".format(INVALID_YEAR, HAS_HEADER))
 
     sys.exit(os.EX_OK if INVALID_UTF8 == 0 and INVALID_YEAR == 0 else os.EX_SOFTWARE)

--- a/tools/extract_deprecation.py
+++ b/tools/extract_deprecation.py
@@ -82,9 +82,7 @@ def _check_file(path) -> str:
 
 
 if __name__ == "__main__":
-    PARSER = argparse.ArgumentParser(
-        description="Qiskit Extract Deprecation Messages Tool"
-    )
+    PARSER = argparse.ArgumentParser(description="Qiskit Extract Deprecation Messages Tool")
     PARSER.add_argument(
         "-file", type=_check_file, required=True, metavar="file", help="Input file."
     )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
A copy from https://github.com/Qiskit/qiskit-nature/pull/172.
Adds the missing `pyproject.toml` file.


### Details and comments
The reason for many of the "odd" reformattings part of #81 is the missing configuration file.
Most notable, the missing settings for the line-length! black defaults to a line-length of 88 which obviously caused many changes in our code-base (which uses a line-length of 100).

