### PR TITLE
Add a new `initial_point` property to neural network classifiers/regressors

### DIFF
--- a/qiskit_machine_learning/algorithms/classifiers/vqc.py
+++ b/qiskit_machine_learning/algorithms/classifiers/vqc.py
@@ -38,6 +38,7 @@ class VQC(NeuralNetworkClassifier):
         optimizer: Optimizer = None,
         warm_start: bool = False,
         quantum_instance: QuantumInstance = None,
+        initial_point: np.ndarray = None,
     ) -> None:
         """
         Args:
@@ -48,6 +49,7 @@ class VQC(NeuralNetworkClassifier):
             loss: A target loss function to be used in training. Default is cross entropy.
             optimizer: An instance of an optimizer to be used in training.
             warm_start: Use weights from previous fit to start next fit.
+            initial_point: Initial point for the optimizer to start from.
 
         Raises:
             QiskitMachineLearningError: Needs at least one out of num_qubits, feature_map or
@@ -116,6 +118,7 @@ class VQC(NeuralNetworkClassifier):
             one_hot=True,
             optimizer=optimizer,
             warm_start=warm_start,
+            initial_point=initial_point,
         )
 
     @property

--- a/qiskit_machine_learning/algorithms/regressors/neural_network_regressor.py
+++ b/qiskit_machine_learning/algorithms/regressors/neural_network_regressor.py
@@ -39,16 +39,11 @@ class NeuralNetworkRegressor(TrainableModel, RegressorMixin):
         else:
             function = MultiClassObjectiveFunction(X, y, self._neural_network, self._loss)
 
-        if self._warm_start and self._fit_result is not None:
-            initial_point = self._fit_result[0]
-        else:
-            initial_point = np.random.rand(self._neural_network.num_weights)
-
         self._fit_result = self._optimizer.optimize(
             self._neural_network.num_weights,
             function.objective,
             function.gradient,
-            initial_point=initial_point,
+            initial_point=self._choose_initial_point(),
         )
         return self
 

--- a/qiskit_machine_learning/algorithms/regressors/vqr.py
+++ b/qiskit_machine_learning/algorithms/regressors/vqr.py
@@ -13,6 +13,8 @@
 
 from typing import Union, cast
 
+import numpy as np
+
 from qiskit import QuantumCircuit
 from qiskit.algorithms.optimizers import Optimizer
 from qiskit.opflow import OperatorBase
@@ -36,6 +38,7 @@ class VQR(NeuralNetworkRegressor):
         optimizer: Optimizer = None,
         warm_start: bool = False,
         quantum_instance: QuantumInstance = None,
+        initial_point: np.ndarray = None,
     ) -> None:
         r"""
         Args:
@@ -50,6 +53,7 @@ class VQR(NeuralNetworkRegressor):
             loss: A target loss function to be used in training. Default is L2.
             optimizer: An instance of an optimizer to be used in training.
             warm_start: Use weights from previous fit to start next fit.
+            initial_point: Initial point for the optimizer to start from.
 
         Raises:
             QiskitMachineLearningError: Neither num_qubits, nor feature_map, nor ansatz given.
@@ -69,6 +73,7 @@ class VQR(NeuralNetworkRegressor):
             loss=loss,
             optimizer=optimizer,
             warm_start=warm_start,
+            initial_point=initial_point,
         )
 
     @property

--- a/releasenotes/notes/initial-point-277776a7687f1287.yaml
+++ b/releasenotes/notes/initial-point-277776a7687f1287.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Added a parameter ``initial_point`` to the neural network classifiers and regressors.
+    This an array that is passed to an optimizer as an initial point to start from.

--- a/test/algorithms/classifiers/test_neural_network_classifier.py
+++ b/test/algorithms/classifiers/test_neural_network_classifier.py
@@ -206,9 +206,12 @@ class TestNeuralNetworkClassifier(QiskitMachineLearningTestCase):
             output_shape=output_shape,
             quantum_instance=quantum_instance,
         )
-
+        # classification may fail sometimes, so let's fix initial point
+        initial_point = np.array([0.5] * ansatz.num_parameters)
         # construct classifier - note: CrossEntropy requires eval_probabilities=True!
-        classifier = NeuralNetworkClassifier(qnn, optimizer=optimizer, loss=loss, one_hot=True)
+        classifier = NeuralNetworkClassifier(
+            qnn, optimizer=optimizer, loss=loss, one_hot=True, initial_point=initial_point
+        )
 
         # construct data
         num_samples = 5

--- a/test/circuit/library/test_raw_feature_vector.py
+++ b/test/circuit/library/test_raw_feature_vector.py
@@ -82,7 +82,6 @@ class TestRawFeatureVector(QiskitMachineLearningTestCase):
             ref.initialize([0.2, 0.4, 0.4, 0.8], ref.qubits)
             self.assertEqual(bound.decompose(), ref)
 
-    # TODO: currently fails due to the way the RawFeatureVector handles parameters
     def test_usage_in_vqc(self):
         """Test using the circuit the a single VQC iteration works."""
 
@@ -105,12 +104,16 @@ class TestRawFeatureVector(QiskitMachineLearningTestCase):
         y = np.array([y, 1 - y]).transpose()
 
         feature_map = RawFeatureVector(feature_dimension=num_inputs)
+        ansatz = RealAmplitudes(feature_map.num_qubits, reps=1)
+        # classification may fail sometimes, so let's fix initial point
+        initial_point = np.array([0.5] * ansatz.num_parameters)
 
         vqc = VQC(
             feature_map=feature_map,
-            ansatz=RealAmplitudes(feature_map.num_qubits, reps=1),
+            ansatz=ansatz,
             optimizer=COBYLA(maxiter=10),
             quantum_instance=quantum_instance,
+            initial_point=initial_point,
         )
 
         vqc.fit(X, y)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR closes #113.
A new property `initial_point` is added to `NeuralNetworkClassifier`, `NeuralNetworkregressor`, `VQC`, `VQR`.
If a value is specified, then this value is passed to underlying optimizers as an initial point to start from.


