### PR TITLE
Move away from using pylint header plugin

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -108,7 +108,9 @@ precomputes
 precomputing
 priori
 ps
+py
 pytorch
+pxd
 qae
 qarg
 qargs

--- a/.pylintrc
+++ b/.pylintrc
@@ -23,9 +23,6 @@ persistent=yes
 # usually to register additional checkers.
 load-plugins=pylint.extensions.docparams, # enable checking of docstring args
     pylint.extensions.docstyle,  # basic docstring style checks
-    pylintfileheader  # Check license comments
-
-file-header=(?:(?:#[^\n]*)?\n)*# This code is part of Qiskit.\n#\n# \(C\) Copyright IBM [0-9, -]*.\n#\n# This code is licensed under the Apache License, Version 2.0. You may\n# obtain a copy of this license in the LICENSE.txt file in the root directory\n# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.\n#\n# Any modifications or derivative works of this code must retain this\n# copyright notice, and modified files need to carry a notice indicating\n# that they have been altered from the originals.\n
 
 # Use multiple processes to speed up Pylint.
 jobs=1

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ all_check: spell style lint copyright mypy clean_sphinx html doctest
 
 lint:
 	pylint -rn qiskit_machine_learning test tools
+	python tools/verify_headers.py
 
 mypy:
 	mypy qiskit_machine_learning test tools

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ all_check: spell style lint copyright mypy clean_sphinx html doctest
 
 lint:
 	pylint -rn qiskit_machine_learning test tools
-	python tools/verify_headers.py
+	python tools/verify_headers.py qiskit_machine_learning test tools
 
 mypy:
 	mypy qiskit_machine_learning test tools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,6 @@ coverage>=4.4.0
 matplotlib>=2.1
 black==21.4b2
 pylint>=2.7.1
-pylintfileheader>=0.0.2
 pylatexenc>=1.4
 stestr>=2.0.0
 ddt>=1.2.0,!=1.4.0

--- a/tools/verify_headers.py
+++ b/tools/verify_headers.py
@@ -82,17 +82,19 @@ def validate_header(file_path):
 
 
 def _main():
-    default_path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    default_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "qiskit_machine_learning"
+    )
     parser = argparse.ArgumentParser(description="Check file headers.")
     parser.add_argument(
         "paths",
         type=str,
         nargs="*",
         default=[default_path],
-        help="Paths to scan by default uses ../. from the script",
+        help="Paths to scan by default uses ../qiskit_machine_learning from the script",
     )
     args = parser.parse_args()
-    files = discover_files(args.paths, exclude_folders=["docs"])
+    files = discover_files(args.paths, exclude_folders=[])
     with multiprocessing.Pool() as pool:
         res = pool.map(validate_header, files)
     failed_files = [x for x in res if x[1] is False]

--- a/tools/verify_headers.py
+++ b/tools/verify_headers.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+# This code is part of Qiskit.
+#
+# (C) Copyright IBM 2020
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Utility script to verify qiskit copyright file headers"""
+
+import argparse
+import multiprocessing
+import os
+import sys
+import re
+
+# regex for character encoding from PEP 263
+pep263 = re.compile(r"^[ \t\f]*#.*?coding[:=][ \t]*([-_.a-zA-Z0-9]+)")
+
+
+def discover_files(code_paths):
+    """Find all .py, .pyx, .pxd files in a list of trees"""
+    out_paths = []
+    for path in code_paths:
+        if os.path.isfile(path):
+            out_paths.append(path)
+        else:
+            for directory in os.walk(path):
+                dir_path = directory[0]
+                for subfile in directory[2]:
+                    if (
+                        subfile.endswith(".py")
+                        or subfile.endswith(".pyx")
+                        or subfile.endswith(".pxd")
+                    ):
+                        out_paths.append(os.path.join(dir_path, subfile))
+    return out_paths
+
+
+def validate_header(file_path):
+    """Validate the header for a single file"""
+    header = """# This code is part of Qiskit.
+#
+"""
+    apache_text = """#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+"""
+    count = 0
+    with open(file_path, encoding="utf8") as code_file:
+        lines = code_file.readlines()
+    start = 0
+    for index, line in enumerate(lines):
+        count += 1
+        if count > 5:
+            return file_path, False, "Header not found in first 5 lines"
+        if count <= 2 and pep263.match(line):
+            return file_path, False, "Unnecessary encoding specification (PEP 263, 3120)"
+        if line == "# This code is part of Qiskit.\n":
+            start = index
+            break
+    if "".join(lines[start : start + 2]) != header:
+        return (file_path, False, "Header up to copyright line does not match: %s" % header)
+    if not lines[start + 2].startswith("# (C) Copyright IBM 20"):
+        return (file_path, False, "Header copyright line not found")
+    if "".join(lines[start + 3 : start + 11]) != apache_text:
+        return (file_path, False, "Header apache text string doesn't match:\n %s" % apache_text)
+    return (file_path, True, None)
+
+
+def _main():
+    default_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "qiskit_machine_learning"
+    )
+    parser = argparse.ArgumentParser(description="Check file headers.")
+    parser.add_argument(
+        "paths",
+        type=str,
+        nargs="*",
+        default=[default_path],
+        help="Paths to scan by default uses ../qiskit_machine_learning from the script",
+    )
+    args = parser.parse_args()
+    files = discover_files(args.paths)
+    with multiprocessing.Pool() as pool:
+        res = pool.map(validate_header, files)
+    failed_files = [x for x in res if x[1] is False]
+    if len(failed_files) > 0:
+        for failed_file in failed_files:
+            sys.stderr.write("%s failed header check because:\n" % failed_file[0])
+            sys.stderr.write("%s\n\n" % failed_file[2])
+        sys.exit(1)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    _main()

--- a/tools/verify_headers.py
+++ b/tools/verify_headers.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020
+# (C) Copyright IBM 2020, 2021.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ commands =
   pylint -rn qiskit_machine_learning test tools
   mypy qiskit_machine_learning test tools
   python3 {toxinidir}/tools/check_copyright.py -path {toxinidir}
+  python3 {toxinidir}/tools/verify_headers.py
 
 [testenv:black]
 envdir = .tox/lint

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ commands =
   pylint -rn qiskit_machine_learning test tools
   mypy qiskit_machine_learning test tools
   python3 {toxinidir}/tools/check_copyright.py -path {toxinidir}
-  python3 {toxinidir}/tools/verify_headers.py
+  python3 {toxinidir}/tools/verify_headers.py qiskit_machine_learning test tools
 
 [testenv:black]
 envdir = .tox/lint


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Currently we're relying on a pylint plugin to verify copyright headers
conform to the project guidelines. However this is problematic for a
number of reasons. The first is it has proven to be unstable there have
been several instances of both users and CI failing on header files that
do not have any issues. This is pretty common with pylint in general
since it's very sensitive to differences in environment. Additionally,
it was using a regex to try and match the entire header string. This
provided no practical debugability when it fails (especially when the
failure is unexpected) because we end up with only a match error.
This commit addresses these issues by removing the use of the regex
based pylint plugin and copying and adapting the small script qiskit-terra
uses to verify the header in every qiskit file and provide useful debugging
if there is an issue with a header in a python file.

### Details and comments