### PR TITLE
Fixups to API ref documentation

### DIFF
--- a/docs/apidocs/qiskit_machine_learning.connectors.rst
+++ b/docs/apidocs/qiskit_machine_learning.connectors.rst
@@ -1,0 +1,6 @@
+﻿.. _qiskit-machine-learning-connectors:
+
+.. automodule:: qiskit_machine_learning.connectors
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:

--- a/qiskit_machine_learning/__init__.py
+++ b/qiskit_machine_learning/__init__.py
@@ -36,6 +36,7 @@ Submodules
 
    algorithms
    circuit.library
+   connectors
    datasets
    kernels
    neural_networks

--- a/qiskit_machine_learning/connectors/torch_connector.py
+++ b/qiskit_machine_learning/connectors/torch_connector.py
@@ -62,7 +62,7 @@ except ImportError:
 
 
 class TorchConnector(Module):
-    """Connects Qiskit (Quantum) Neural Network to PyTorch."""
+    """Connects a Qiskit (Quantum) Neural Network to PyTorch."""
 
     class _TorchNNFunction(Function):
         # pylint: disable=arguments-differ
@@ -203,8 +203,7 @@ class TorchConnector(Module):
         initial_weights: Optional[Union[np.ndarray, Tensor]] = None,
         sparse: Optional[bool] = None,
     ):
-        """Initializes the TorchConnector.
-
+        """
         Args:
             neural_network: The neural network to be connected to PyTorch.
             initial_weights: The initial weights to start training the network. If this is None,
@@ -237,7 +236,12 @@ class TorchConnector(Module):
     @property  # type: ignore
     @deprecate_property("0.2.0", new_name="weight")
     def weights(self) -> Tensor:
-        """Returns the weights of the underlying network."""
+        """
+        .. deprecated:: 0.2.0
+           Use :meth:`weight` instead.
+
+        Returns the weights of the underlying network.
+        """
         return self.weight
 
     @property
@@ -252,8 +256,10 @@ class TorchConnector(Module):
 
     def forward(self, input_data: Optional[Tensor] = None) -> Tensor:
         """Forward pass.
+
         Args:
             input_data: data to be evaluated.
+
         Returns:
             Result of forward pass of this model.
         """

--- a/qiskit_machine_learning/neural_networks/__init__.py
+++ b/qiskit_machine_learning/neural_networks/__init__.py
@@ -21,6 +21,9 @@ to a discriminative or generative task.
 Neural Networks may be used, for example, with the
 :class:`~qiskit_machine_learning.algorithms.QGAN` algorithm.
 
+See also the :class:`~qiskit_machine_learning.connectors.TorchConnector` that allows the
+use of these neural networks in code written to `PyTorch <https://pytorch.org/>`_.
+
 .. currentmodule:: qiskit_machine_learning.neural_networks
 
 Neural Network Base Classes
@@ -31,6 +34,7 @@ Neural Network Base Classes
    :nosignatures:
 
    NeuralNetwork
+   SamplingNeuralNetwork
 
 Neural Networks
 ===============
@@ -39,10 +43,8 @@ Neural Networks
    :toctree: ../stubs/
    :nosignatures:
 
-   NeuralNetwork
    OpflowQNN
    TwoLayerQNN
-   SamplingNeuralNetwork
    CircuitQNN
 
 """

--- a/qiskit_machine_learning/neural_networks/circuit_qnn.py
+++ b/qiskit_machine_learning/neural_networks/circuit_qnn.py
@@ -63,8 +63,7 @@ class CircuitQNN(SamplingNeuralNetwork):
         quantum_instance: Optional[Union[QuantumInstance, BaseBackend, Backend]] = None,
         input_gradients: bool = False,
     ) -> None:
-        """Initializes the Circuit Quantum Neural Network.
-
+        """
         Args:
             circuit: The parametrized quantum circuit that generates the samples of this network.
             input_params: The parameters of the circuit corresponding to the input.

--- a/qiskit_machine_learning/neural_networks/neural_network.py
+++ b/qiskit_machine_learning/neural_networks/neural_network.py
@@ -47,7 +47,7 @@ class NeuralNetwork(ABC):
         output_shape: Union[int, Tuple[int, ...]],
         input_gradients: bool = False,
     ) -> None:
-        """Initializes the Neural Network.
+        """
         Args:
             num_inputs: The number of input features.
             num_weights: The number of trainable weights.

--- a/qiskit_machine_learning/neural_networks/opflow_qnn.py
+++ b/qiskit_machine_learning/neural_networks/opflow_qnn.py
@@ -61,8 +61,7 @@ class OpflowQNN(NeuralNetwork):
         quantum_instance: Optional[Union[QuantumInstance, BaseBackend, Backend]] = None,
         input_gradients: bool = False,
     ):
-        """Initializes the Opflow Quantum Neural Network.
-
+        """
         Args:
             operator: The parametrized operator that represents the neural network.
             input_params: The operator parameters that correspond to the input of the network.

--- a/qiskit_machine_learning/neural_networks/two_layer_qnn.py
+++ b/qiskit_machine_learning/neural_networks/two_layer_qnn.py
@@ -40,8 +40,7 @@ class TwoLayerQNN(OpflowQNN):
         quantum_instance: Optional[Union[QuantumInstance, BaseBackend, Backend]] = None,
         input_gradients: bool = False,
     ):
-        r"""Initializes the Two Layer Quantum Neural Network.
-
+        r"""
         Args:
             num_qubits: The number of qubits to represent the network, if None and neither the
                 feature_map not the ansatz are given, raise exception.


### PR DESCRIPTION
Several fixups to docs, including:

* Fix NeuralNetwork so its docstring formats correctly
* Remove the duplicate of it from the index
* Include connectors to the index and hence TorchConnector into the docs which otherwise was missing
* Several other minor text changes/fixes