### PR TITLE
Exclude locale from the sync path

### DIFF
--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -26,4 +26,4 @@ pwd
 # Push to qiskit.org website
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
 echo "Pushing built docs to website"
-rclone sync --progress --exclude-from ./locale/** ./docs/_build/html IBMCOS:qiskit-org-web-resources/documentation/machine-learning
+rclone sync --progress --exclude ./locale/** ./docs/_build/html IBMCOS:qiskit-org-web-resources/documentation/machine-learning

--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -26,4 +26,4 @@ pwd
 # Push to qiskit.org website
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
 echo "Pushing built docs to website"
-rclone sync --progress --exclude ./locale/** ./docs/_build/html IBMCOS:qiskit-org-web-resources/documentation/machine-learning
+rclone sync --progress --exclude locale/** ./docs/_build/html IBMCOS:qiskit-org-web-resources/documentation/machine-learning

--- a/tools/deploy_documentation.sh
+++ b/tools/deploy_documentation.sh
@@ -26,4 +26,4 @@ pwd
 # Push to qiskit.org website
 openssl aes-256-cbc -K $encrypted_rclone_key -iv $encrypted_rclone_iv -in tools/rclone.conf.enc -out $RCLONE_CONFIG_PATH -d
 echo "Pushing built docs to website"
-rclone sync --progress ./docs/_build/html IBMCOS:qiskit-org-web-resources/documentation/machine-learning
+rclone sync --progress --exclude-from ./locale/** ./docs/_build/html IBMCOS:qiskit-org-web-resources/documentation/machine-learning


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

As mentioned in the review comment https://github.com/qiskit-community/qiskit-translations/pull/686#discussion_r669534783, rclone has to exclude locale from the sync path otherwise when machine learning goes to push an update it will delete all the contents from the locale path.

### Details and comments

This PR has a higher priority than #160.

#### Order of merging
- This PR 
- https://github.com/qiskit-community/qiskit-translations/pull/686
- #160
