### PR TITLE
Torch Module fails to import on sphinx >= 4.1.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ pylatexenc>=1.4
 stestr>=2.0.0
 ddt>=1.2.0,!=1.4.0
 reno>=3.2.0
-Sphinx>=1.8.3,!=3.1.0,<4.1.0
+Sphinx>=1.8.3,!=3.1.0
 sphinx-panels
 sphinx-gallery
 sphinx-autodoc-typehints


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary


### Details and comments
torch.nn.Module fails to load as a base class during Sphinx html build for Sphinx >= 4.1.0
Mocking this class in conf.py as recommended works but requires patching the class name in order to
show it correctly in the base class list. More info on a similar problem:
sphinx-doc/sphinx#6521

