### PR TITLE
Qiskit/qiskit#1303 change Markdown link to reStructuredText syntax

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -94,7 +94,7 @@ Optional installs
 =================
 
 * **PyTorch**, may be installed either using command `pip install 'qiskit-machine-learning[torch]'` to install the
-  package or refer to PyTorch [getting started](https://pytorch.org/get-started/locally/). When PyTorch
+  package or refer to PyTorch `getting started <https://pytorch.org/get-started/locally/>`__. When PyTorch
   is installed, the `TorchConnector` facilitates its use of quantum computed networks.
 
 * **Sparse**, may be installed using command `pip install 'qiskit-machine-learning[sparse]'` to install the


### PR DESCRIPTION
Fix https://github.com/Qiskit/qiskit/issues/1303