### PR TITLE
Batching of circuits to overcome memory issues when using statevector simulator

### DIFF
--- a/qiskit_machine_learning/kernels/quantum_kernel.py
+++ b/qiskit_machine_learning/kernels/quantum_kernel.py
@@ -282,18 +282,16 @@ class QuantumKernel:
                 is_statevector_sim=is_statevector_sim,
             )
             parameterized_circuit = self._quantum_instance.transpile(parameterized_circuit)[0]
-            circuits = [
-                parameterized_circuit.assign_parameters({feature_map_params: x})
-                for x in to_be_computed_data
-            ]
-
             statevectors = []
 
-            for min_idx in range(0, len(circuits), self._batch_size):
-                max_idx = min(min_idx + self._batch_size, len(circuits))
-                num_circuits = max_idx - min_idx
-                results = self._quantum_instance.execute(circuits[min_idx : max_idx])
-                for j in range(num_circuits):
+            for min_idx in range(0, len(to_be_computed_data), self._batch_size):
+                max_idx = min(min_idx + self._batch_size, len(to_be_computed_data))
+                circuits = [
+                    parameterized_circuit.assign_parameters({feature_map_params: x})
+                    for x in to_be_computed_data[min_idx : max_idx]
+                ]
+                results = self._quantum_instance.execute(circuits)
+                for j in range(max_idx - min_idx):
                     statevectors.append(results.get_statevector(j))
 
             offset = 0 if is_symmetric else len(x_vec)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Currently `batch_size` parameter is ignored if the statevector simulator is used. This leads to unreasonable memory use due to the size of the transpiled circuits, up to 1TB of RAM for 800 by 800 kernel matrix and 20 qubits (see [qiskit-terra, issue #6991](https://github.com/Qiskit/qiskit-terra/issues/6991)). This pull request fixes this by transpiling and simulating circuits in batches, never storing the entire 800 circuits. The modification uses `batch_size` parameter that is already used in non-statevector case.

### Details and comments

I had success by setting `batch_size=50` (memory footprint down to <20 GB).

