### PR TITLE
Add support for tunable feature maps in QuantumKernel class.

### DIFF
--- a/test/kernels/test_qkernel.py
+++ b/test/kernels/test_qkernel.py
@@ -12,6 +12,7 @@
 
 """ Test QuantumKernel """
 
+import numbers
 import unittest
 
 from test import QiskitMachineLearningTestCase
@@ -356,6 +357,67 @@ class TestQuantumKernelConstructCircuit(QiskitMachineLearningTestCase):
 
         with self.assertRaises(ValueError):
             _ = qkclass.construct_circuit(self.x, self.z)
+
+
+class TestQuantumKernelFreeParameters(QiskitMachineLearningTestCase):
+    """Test QuantumKernel free parameter support"""
+
+    def setUp(self):
+        super().setUp()
+
+        # Create an arbitrary 2-qubit feature map circuit
+        circ1 = ZZFeatureMap(2)
+        circ2 = ZZFeatureMap(2)
+        free_params = circ2.parameters
+        for i, _ in enumerate(free_params):
+            free_params[i]._name = "θ[{}]".format(i)
+
+        self.feature_map = circ1.compose(circ2).compose(circ1)
+        self.free_parameters = free_params
+
+    def test_free_parameters(self):
+        """Test assigning free parameters"""
+        # Ensure we can instantiate a QuantumKernel with free parameters
+        qkclass = QuantumKernel(feature_map=self.feature_map, free_parameters=self.free_parameters)
+        self.assertEqual(qkclass.free_parameters, self.free_parameters)
+
+        # Test iterative free parameter binding
+        qkclass.assign_free_parameters({qkclass.free_parameters[0]: np.pi / 2})
+        self.assertEqual(len(qkclass.feature_map.parameters), 3)
+        qkclass.assign_free_parameters({qkclass.free_parameters[1]: np.pi / 2})
+        self.assertEqual(len(qkclass.feature_map.parameters), 2)
+
+        # Instantiate a QuantumKernel without specifying free parameters
+        qkclass = QuantumKernel(feature_map=self.feature_map)
+
+        # Case where user assigns param values without specifying params
+        free_param_values = [np.pi / 2, np.pi / 4]
+        with self.assertRaises(ValueError):
+            qkclass.assign_free_parameters(free_param_values)
+
+        # Bind free parameters to real values
+        param_binds = dict(zip(self.free_parameters, free_param_values))
+        qkclass.assign_free_parameters(param_binds)
+
+        # Ensure the two free parameters were bound correctly
+        bound_free_param_vals = [
+            val for val in qkclass.free_param_binds.values() if isinstance(val, numbers.Number)
+        ]
+        self.assertEqual(free_param_values, bound_free_param_vals)
+
+        # Assign params to some new values, and also test the bind_free_parameters interface
+        free_param_values = [np.pi / 4, np.pi / 2]
+        param_binds = dict(zip(self.free_parameters, free_param_values))
+        qkclass.bind_free_parameters(param_binds)
+
+        # Ensure the old values are properly overwritten in the feature map
+        bound_free_param_vals = [
+            val for val in qkclass.free_param_binds.values() if isinstance(val, numbers.Number)
+        ]
+        self.assertEqual(free_param_values, bound_free_param_vals)
+
+        # Ensure base feature map still holds all parameters of input feature map
+        self.assertEqual(len(qkclass.base_feature_map.parameters), 4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Closes #215 
Currently, qiskit-machine-learning.kernels.QuantumKernel (QK) only supports feature map circuits which contain a number of parameters equal to the dimensionality of the input data, and it provides no interface for clients to update/bind parameters manually. This makes it cumbersome for clients to use QK within algorithms which require many updates to feature map parameters.

This pull request provides updates to the QuantumKernel class which facilitate binding and re-binding tunable feature map parameters.

### Details and comments
All source code changes are contained within `qiskit_machine_learning.kernels.quantum_kernel.py` and the associated test module.
