### PR TITLE
Disable pylint consider-using-f-string for now

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -72,7 +72,8 @@ disable=no-self-use,        # disabled as it is too verbose
     no-else-return,     # relax "elif" after a clause with a return
     docstring-first-line-empty, # relax docstring style
     import-outside-toplevel,
-    bad-continuation, bad-whitespace # differences of opinion with black
+    bad-continuation, bad-whitespace, # differences of opinion with black
+    consider-using-f-string
 
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
New pylint version: Due to the numerous places where this lint error happens, I am disabling it for now until all the places are changed to use f strings


### Details and comments


