### PR TITLE
Transpile circuit in CircuitQNN for better performance

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -165,6 +165,7 @@ toctree
 todo
 traceback
 transpilation
+transpile
 transpiled
 uncompiled
 unitaries

--- a/.pylintdict
+++ b/.pylintdict
@@ -168,6 +168,7 @@ transpilation
 transpile
 transpiled
 uncompiled
+transpiling
 unitaries
 univariate
 unsymmetric

--- a/qiskit_machine_learning/neural_networks/circuit_qnn.py
+++ b/qiskit_machine_learning/neural_networks/circuit_qnn.py
@@ -286,9 +286,8 @@ class CircuitQNN(SamplingNeuralNetwork):
             except QiskitError as ex:
                 # likely it is caused by RawFeatureVector
                 logger.warning(
-                    "There was an exception transpiling the circuit provided and it is ignored. "
-                    "Please ensure your circuit can be transpiled, "
-                    "otherwise overall performance on the QNN may decrease.",
+                    "The supplied circuit could not be pre-transpiled for subsequent usages "
+                    "which may impact overall performance",
                     exc_info=ex,
                 )
                 self._circuit_transpiled = False

--- a/releasenotes/notes/circuit-qnn-transpile-c2fe7eae3afedf2d.yaml
+++ b/releasenotes/notes/circuit-qnn-transpile-c2fe7eae3afedf2d.yaml
@@ -4,10 +4,7 @@ features:
     There's an additional transpilation step introduced in CircuitQNN that is invoked when
     a quantum instance is set. A circuit passed to ``CircuitQNN`` is transpiled and saved for
     subsequent usages. So, every time when the circuit is executed it is already transpiled and
-    overall time of the forward pass is reduced.
-
-issues:
-  - |
-    Due to implementation limitations of `RawFeatureVector` it can't be transpiled in advance, so
-    it is transpiled every time it is required to be executed and only when all parameters are
-    bound. This may impact overall performance on the network.
+    overall time of the forward pass is reduced. Due to implementation limitations of
+    ``RawFeatureVector`` it can't be transpiled in advance, so it is transpiled every time
+    it is required to be executed and only when all parameters are bound. This means overall
+    performance when ``RawFeatureVector`` is used stays the same.

--- a/releasenotes/notes/circuit-qnn-transpile-c2fe7eae3afedf2d.yaml
+++ b/releasenotes/notes/circuit-qnn-transpile-c2fe7eae3afedf2d.yaml
@@ -1,0 +1,14 @@
+---
+features:
+  - |
+    There's an additional transpilation step introduced in CircuitQNN that is executed when
+    a quantum instance is set. A circuit passed to ``CircuitQNN`` is transpiled and saved for
+    further re-use. So, every time when the circuit is executed it is already transpiled and
+    overall time of the forward pass is reduced.
+issues:
+  - |
+    When ``RawFeatureVector`` is used by a ``CircuitQNN``-based model a warning may be raised
+    saying that there was an exception transpiling the circuit. This is a known issue,
+    ``RawFeatureVector`` can't be transpiled until all parameters are bound and this is a reason
+     for this warning. In this case a circuit based on ``RawFeatureMap`` is used as is and
+    transpiled every time it is executed.

--- a/releasenotes/notes/circuit-qnn-transpile-c2fe7eae3afedf2d.yaml
+++ b/releasenotes/notes/circuit-qnn-transpile-c2fe7eae3afedf2d.yaml
@@ -1,15 +1,13 @@
 ---
 features:
   - |
-    There's an additional transpilation step introduced in CircuitQNN that is executed when
+    There's an additional transpilation step introduced in CircuitQNN that is invoked when
     a quantum instance is set. A circuit passed to ``CircuitQNN`` is transpiled and saved for
-    further re-use. So, every time when the circuit is executed it is already transpiled and
+    subsequent usages. So, every time when the circuit is executed it is already transpiled and
     overall time of the forward pass is reduced.
 
 issues:
   - |
-    When ``RawFeatureVector`` is used by a ``CircuitQNN``-based model a warning may be raised
-    saying that there was an exception transpiling the circuit. This is a known issue,
-    ``RawFeatureVector`` can't be transpiled until all parameters are bound and this is a reason
-    for this warning. In this case a circuit based on ``RawFeatureMap`` is used as is and
-    transpiled every time it is executed.
+    Due to implementation limitations of `RawFeatureVector` it can't be transpiled in advance, so
+    it is transpiled every time it is required to be executed and only when all parameters are
+    bound. This may impact overall performance on the network.

--- a/releasenotes/notes/circuit-qnn-transpile-c2fe7eae3afedf2d.yaml
+++ b/releasenotes/notes/circuit-qnn-transpile-c2fe7eae3afedf2d.yaml
@@ -5,10 +5,11 @@ features:
     a quantum instance is set. A circuit passed to ``CircuitQNN`` is transpiled and saved for
     further re-use. So, every time when the circuit is executed it is already transpiled and
     overall time of the forward pass is reduced.
+
 issues:
   - |
     When ``RawFeatureVector`` is used by a ``CircuitQNN``-based model a warning may be raised
     saying that there was an exception transpiling the circuit. This is a known issue,
     ``RawFeatureVector`` can't be transpiled until all parameters are bound and this is a reason
-     for this warning. In this case a circuit based on ``RawFeatureMap`` is used as is and
+    for this warning. In this case a circuit based on ``RawFeatureMap`` is used as is and
     transpiled every time it is executed.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Currently every time when `CircuitQNN` executes a circuit it is transpiled internally by `QuantumInstance`. Thus, overall fir time of a model based on `CircuitQNN` is larger than it could be. In this PR we introduce an additional transpilation step in `CircuitQNN` that is done when a quantum instance is set. The circuit is transpiled and saved for further re-use. So, every time when the circuit is executed it is already transpiled and overall time of the forward pass is reduced.

### Details and comments
A simple model based on the iris dataset shows a decrease in fit time from 39.5 to 25 seconds on 5 iterations.

This enhancement does not work with `RawFeatureVector`. This feature map can't be transpiled until all parameters are bound, hence it can not be transpiled in advance. This is a known problem.

