### PR TITLE
Added missing had_transpiled=True to quantum_kernel

### DIFF
--- a/.pylintdict
+++ b/.pylintdict
@@ -167,6 +167,8 @@ traceback
 transpilation
 transpile
 transpiled
+transpiler
+transpiles
 uncompiled
 transpiling
 unitaries

--- a/qiskit_machine_learning/kernels/quantum_kernel.py
+++ b/qiskit_machine_learning/kernels/quantum_kernel.py
@@ -428,7 +428,7 @@ class QuantumKernel:
                     parameterized_circuit.assign_parameters({feature_map_params: x})
                     for x in to_be_computed_data[min_idx:max_idx]
                 ]
-                results = self._quantum_instance.execute(circuits)
+                results = self._quantum_instance.execute(circuits, had_transpiled=True)
                 for j in range(max_idx - min_idx):
                     statevectors.append(results.get_statevector(j))
 
@@ -473,7 +473,7 @@ class QuantumKernel:
                     for x, y in to_be_computed_data_pair
                 ]
 
-                results = self._quantum_instance.execute(circuits)
+                results = self._quantum_instance.execute(circuits, had_transpiled=True)
 
                 matrix_elements = [
                     self._compute_overlap(circuit, results, is_statevector_sim, measurement_basis)

--- a/releasenotes/notes/qsvm-transpiler-fix-13ab6b22a837d2b5.yaml
+++ b/releasenotes/notes/qsvm-transpiler-fix-13ab6b22a837d2b5.yaml
@@ -1,0 +1,7 @@
+---
+features:
+  - |
+    ``QuantumKernel`` transpiles all circuits before execution. However, this
+     information was not being passed, which calls the transpiler many times
+     during the execution of the ``QSVM`` algorithm. Now, ``had_transpiled=True``
+     is passed correctly and the algorithm runs faster.

--- a/releasenotes/notes/qsvm-transpiler-fix-13ab6b22a837d2b5.yaml
+++ b/releasenotes/notes/qsvm-transpiler-fix-13ab6b22a837d2b5.yaml
@@ -3,5 +3,5 @@ features:
   - |
     ``QuantumKernel`` transpiles all circuits before execution. However, this
      information was not being passed, which calls the transpiler many times
-     during the execution of the ``QSVM`` algorithm. Now, ``had_transpiled=True``
+     during the execution of the ``QSVC/QSVR`` algorithm. Now, ``had_transpiled=True``
      is passed correctly and the algorithm runs faster.


### PR DESCRIPTION
### Summary

Circuits are being transpiled in `quantum_kernel.py` but the necessary `had_transpiled=True` flag is not being passed when the circuits are being executed. This makes the transpilation operation re-run many times and this slows down the QSVM algorithm. 

### Details and comments

A test with the IRIS dataset is performed for 10 data samples from 2 classes is performed. Run times are given below:

Before the change: 55.0 seconds
After the change: 5.56 seconds