### PR TITLE
Pass `exp_val` in the constructor of TwoLayerQNN to the superclass contructor

### DIFF
--- a/qiskit_machine_learning/neural_networks/two_layer_qnn.py
+++ b/qiskit_machine_learning/neural_networks/two_layer_qnn.py
@@ -50,6 +50,9 @@ class TwoLayerQNN(OpflowQNN):
                 the `RealAmplitudes` circuit is used.
             observable: observable to be measured to determine the output of the network. If None
                 is given, the `Z^{\otimes num_qubits}` observable is used.
+            exp_val: The Expected Value converter to be used for the operator obtained from the
+                feature map and ansatz.
+            quantum_instance: The quantum instance to evaluate the network.
             input_gradients: Determines whether to compute gradients with respect to input data.
                 Note that this parameter is ``False`` by default, and must be explicitly set to
                 ``True`` for a proper gradient computation when using ``TorchConnector``.

--- a/qiskit_machine_learning/neural_networks/two_layer_qnn.py
+++ b/qiskit_machine_learning/neural_networks/two_layer_qnn.py
@@ -115,9 +115,10 @@ class TwoLayerQNN(OpflowQNN):
         operator = ~StateFn(self.observable) @ StateFn(self._circuit)
 
         super().__init__(
-            operator,
-            input_params,
-            weight_params,
+            operator=operator,
+            input_params=input_params,
+            weight_params=weight_params,
+            exp_val=exp_val,
             quantum_instance=quantum_instance,
             input_gradients=input_gradients,
         )

--- a/releasenotes/notes/fix-exp-val-two-layer-qnn-5d65cf5c706f3e08.yaml
+++ b/releasenotes/notes/fix-exp-val-two-layer-qnn-5d65cf5c706f3e08.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    ``TwoLayerQNN`` now passes the value of the ``exp_val`` parameter in the constructor to
+    the constructor of ``OpflowNN`` which ``TwoLayerQNN`` inherits from.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Parameter `exp_val` in the constructor of `TwoLayerQNN` was not used. Now it is passed to the superclass constructor in `OpflowQNN`.

