### PR TITLE
Fix VQC training on multiclass datasets

### DIFF
--- a/qiskit_machine_learning/algorithms/classifiers/vqc.py
+++ b/qiskit_machine_learning/algorithms/classifiers/vqc.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -167,7 +167,6 @@ class VQC(NeuralNetworkClassifier):
         return super().fit(X, y)
 
     def _get_interpret(self, num_classes: int):
-
         def parity(x: int, num_classes: int = num_classes) -> int:
             return x % num_classes
 

--- a/qiskit_machine_learning/algorithms/classifiers/vqc.py
+++ b/qiskit_machine_learning/algorithms/classifiers/vqc.py
@@ -166,8 +166,9 @@ class VQC(NeuralNetworkClassifier):
         )
         return super().fit(X, y)
 
-    def _get_interpret(self, num_classes):
-        def parity(x, num_classes=num_classes):
-            return f"{x:b}".count("1") % num_classes
+    def _get_interpret(self, num_classes: int):
+
+        def parity(x: int, num_classes: int = num_classes) -> int:
+            return x % num_classes
 
         return parity

--- a/qiskit_machine_learning/utils/loss_functions/loss_functions.py
+++ b/qiskit_machine_learning/utils/loss_functions/loss_functions.py
@@ -155,8 +155,8 @@ class CrossEntropyLoss(Loss):
         # multiply target and log(predict) matrices row by row and sum up each row
         # into a single float, so the output is of shape(N,), where N number or samples.
         # then reshape
-        val = -np.einsum("ij,ij->i", target, np.log2(predict)).reshape(-1, 1)
 
+        val = -np.einsum("ij,ij->i", target, np.log2(predict + 1e-10)).reshape(-1, 1)
         return val
 
     def gradient(self, predict: np.ndarray, target: np.ndarray) -> np.ndarray:

--- a/qiskit_machine_learning/utils/loss_functions/loss_functions.py
+++ b/qiskit_machine_learning/utils/loss_functions/loss_functions.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -155,8 +155,11 @@ class CrossEntropyLoss(Loss):
         # multiply target and log(predict) matrices row by row and sum up each row
         # into a single float, so the output is of shape(N,), where N number or samples.
         # then reshape
-
-        val = -np.einsum("ij,ij->i", target, np.log2(predict + 1e-10)).reshape(-1, 1)
+        # before taking the log we clip the predicted probabilities at a small positive number. This
+        # ensures that in cases where a class is predicted to have 0 probability we don't get nans.
+        val = -np.einsum(
+            "ij,ij->i", target, np.log2(np.clip(predict, a_min=1e-10, a_max=None))
+        ).reshape(-1, 1)
         return val
 
     def gradient(self, predict: np.ndarray, target: np.ndarray) -> np.ndarray:

--- a/releasenotes/notes/fix-multiclass-classification-2fe698bec614fd4d.yaml
+++ b/releasenotes/notes/fix-multiclass-classification-2fe698bec614fd4d.yaml
@@ -1,0 +1,14 @@
+---
+fixes:
+  - |
+    Fixes an issue where `VQC` could not be trained on multiclass datasets.
+    It returned `nan` values on some iterations. This is fixed in 2 ways.
+    First, the default parity function is now guaranteed to be able to assign
+    at least one output bitstring to each class, so long as `2**N >= C` where `N`
+    is the number of output qubits and `C` is the number of classes. This
+    guarantees that it is at least possible for every class to be predicted with a
+    non-zero probability. Second, even with this change it is still possible
+    that on a given training instance a class is predicted with 0 probability.
+    Previously this could lead to `nan` in the `CrossEntropyLoss` calculation.
+    We now replace 0 probabilities with a small positive value to ensure the
+    loss cannot return `nan`.

--- a/test/algorithms/classifiers/test_vqc.py
+++ b/test/algorithms/classifiers/test_vqc.py
@@ -48,6 +48,67 @@ class TestVQC(QiskitMachineLearningTestCase):
         )
 
     @data(
+    # optimizer, quantum instance
+    ("cobyla", "statevector"),
+    ("cobyla", "qasm"),
+    ("bfgs", "statevector"),
+    ("bfgs", "qasm"),
+    (None, "statevector"),
+    (None, "qasm"),
+    )
+    def test_multiclass(self, config):
+        opt, q_i = config
+
+        if q_i == "statevector":
+            quantum_instance = self.sv_quantum_instance
+        else:
+            quantum_instance = self.qasm_quantum_instance
+
+        if opt == "bfgs":
+            optimizer = L_BFGS_B(maxiter=5)
+        elif opt == "cobyla":
+            optimizer = COBYLA(maxiter=25)
+        else:
+            optimizer = None
+
+        num_inputs = 2
+        feature_map = ZZFeatureMap(num_inputs)
+        ansatz = RealAmplitudes(num_inputs, reps=1)
+        # fix the initial point
+        initial_point = np.array([0.5] * ansatz.num_parameters)
+
+        # construct classifier - note: CrossEntropy requires eval_probabilities=True!
+        classifier = VQC(
+            feature_map=feature_map,
+            ansatz=ansatz,
+            optimizer=optimizer,
+            quantum_instance=quantum_instance,
+            initial_point=initial_point,
+        )
+
+        # construct data
+        num_samples = 5
+        num_classes = 5
+        # pylint: disable=invalid-name
+
+        X = algorithm_globals.random.random((num_samples, num_inputs))
+        X = X[X.sum(1).argsort()]
+        y_indices = np.digitize(np.arange(0, 1, 1/num_samples), np.arange(0, 1, 1/num_classes)) - 1
+        permutation = np.random.permutation(np.arange(num_samples))
+        X = X[permutation]
+        y_indices = y_indices[permutation]
+        y = np.zeros((num_samples, num_classes))
+        for e, index in enumerate(y_indices):
+            y[e, index] = 1
+
+        # fit to data
+        classifier.fit(X, y)
+
+        # score
+        score = classifier.score(X, y)
+        self.assertGreater(score, 1 / num_classes)
+
+    @data(
         # optimizer, quantum instance
         ("cobyla", "statevector"),
         ("cobyla", "qasm"),

--- a/test/algorithms/classifiers/test_vqc.py
+++ b/test/algorithms/classifiers/test_vqc.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2021.
+# (C) Copyright IBM 2018, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -48,13 +48,13 @@ class TestVQC(QiskitMachineLearningTestCase):
         )
 
     @data(
-    # optimizer, quantum instance
-    ("cobyla", "statevector"),
-    ("cobyla", "qasm"),
-    ("bfgs", "statevector"),
-    ("bfgs", "qasm"),
-    (None, "statevector"),
-    (None, "qasm"),
+        # optimizer, quantum instance
+        ("cobyla", "statevector"),
+        ("cobyla", "qasm"),
+        ("bfgs", "statevector"),
+        ("bfgs", "qasm"),
+        (None, "statevector"),
+        (None, "qasm"),
     )
     def test_multiclass(self, config):
         opt, q_i = config
@@ -93,7 +93,9 @@ class TestVQC(QiskitMachineLearningTestCase):
 
         X = algorithm_globals.random.random((num_samples, num_inputs))
         X = X[X.sum(1).argsort()]
-        y_indices = np.digitize(np.arange(0, 1, 1/num_samples), np.arange(0, 1, 1/num_classes)) - 1
+        y_indices = (
+            np.digitize(np.arange(0, 1, 1 / num_samples), np.arange(0, 1, 1 / num_classes)) - 1
+        )
         permutation = np.random.permutation(np.arange(num_samples))
         X = X[permutation]
         y_indices = y_indices[permutation]

--- a/test/utils/loss_functions/test_loss_functions.py
+++ b/test/utils/loss_functions/test_loss_functions.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -27,11 +27,14 @@ class TestLossFunctions(QiskitMachineLearningTestCase):
 
     @data(
         # predict, target, expected_loss
-        (np.array([.5, .5]), np.array([1., 0.]), 1.),
-        (np.array([.9999999, .0000001]), np.array([1., 0.]), 0.),
-        (np.array([1., 0.]), np.array([1., 0.]), 0.),
+        (np.array([0.5, 0.5]), np.array([1.0, 0.0]), 1.0),
+        (np.array([1.0, 0.0]), np.array([1.0, 0.0]), 0.0),
     )
     def test_cross_entropy_loss(self, config):
+        """
+        Tests that CrossEntropyLoss returns the correct value, and no nans when one of the
+        probabilities is zero.
+        """
         predict, target, expected_loss = config
         loss_fn = CrossEntropyLoss()
         loss = loss_fn.evaluate(predict, target)

--- a/test/utils/loss_functions/test_loss_functions.py
+++ b/test/utils/loss_functions/test_loss_functions.py
@@ -18,12 +18,24 @@ from qiskit.exceptions import MissingOptionalLibraryError
 import numpy as np
 from ddt import ddt, data
 
-from qiskit_machine_learning.utils.loss_functions import L1Loss, L2Loss
+from qiskit_machine_learning.utils.loss_functions import CrossEntropyLoss, L1Loss, L2Loss
 
 
 @ddt
 class TestLossFunctions(QiskitMachineLearningTestCase):
     """Tests of loss functions."""
+
+    @data(
+        # predict, target, expected_loss
+        (np.array([.5, .5]), np.array([1., 0.]), 1.),
+        (np.array([.9999999, .0000001]), np.array([1., 0.]), 0.),
+        (np.array([1., 0.]), np.array([1., 0.]), 0.),
+    )
+    def test_cross_entropy_loss(self, config):
+        predict, target, expected_loss = config
+        loss_fn = CrossEntropyLoss()
+        loss = loss_fn.evaluate(predict, target)
+        assert np.allclose(loss, expected_loss, atol=1e-5)
 
     @data(
         # input shape, loss shape


### PR DESCRIPTION
Summary
Fixes #251  where VQC couldn't be trained on multiclass datasets. This is fixed by a change to the default parity function of VQC and ensuring CrossEntropyLoss cannot return nan.

Details and comments
Changelog: Bugfix