### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,12 +103,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, '3.10']
         include:
           - os: macos-latest
             python-version: 3.8
+          - os: macos-latest
+            python-version: '3.10'
           - os: windows-latest
             python-version: 3.8
+          - os: windows-latest
+            python-version: '3.10'
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -122,7 +126,7 @@ jobs:
       - run: make lint
         shell: bash
       - run: make mypy
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && matrix.python-version != '3.10' }}
         shell: bash
       - name: Run make lint latest version
         run: |
@@ -246,32 +250,44 @@ jobs:
       - uses: actions/download-artifact@v2
         with:
           name: ubuntu-latest-3.7
-          path: /tmp/m37
+          path: /tmp/u37
       - uses: actions/download-artifact@v2
         with:
           name: ubuntu-latest-3.8
-          path: /tmp/m38
+          path: /tmp/u38
       - uses: actions/download-artifact@v2
         with:
           name: ubuntu-latest-3.9
-          path: /tmp/m39
+          path: /tmp/u39
+      - uses: actions/download-artifact@v2
+        with:
+          name: ubuntu-latest-3.10
+          path: /tmp/u310
       - uses: actions/download-artifact@v2
         with:
           name: macos-latest-3.8
           path: /tmp/m38
       - uses: actions/download-artifact@v2
         with:
+          name: macos-latest-3.10
+          path: /tmp/m310
+      - uses: actions/download-artifact@v2
+        with:
           name: windows-latest-3.8
           path: /tmp/w38
+      - uses: actions/download-artifact@v2
+        with:
+          name: windows-latest-3.10
+          path: /tmp/w310
       - name: Install Dependencies
         run: pip install -U coverage coveralls diff-cover
         shell: bash
       - name: Combined Deprecation Messages
         run: |
-          sort -f -u /tmp/m37/ml.dep /tmp/m38/ml.dep /tmp/m39/ml.dep /tmp/m38/ml.dep /tmp/w38/ml.dep || true
+          sort -f -u /tmp/u37/ml.dep /tmp/u38/ml.dep /tmp/u39/ml.dep /tmp/u310/ml.dep /tmp/m38/ml.dep /tmp/m310/ml.dep /tmp/w38/ml.dep /tmp/w310/ml.dep || true
         shell: bash
       - name: Coverage combine
-        run: coverage3 combine /tmp/m37/ml.dat
+        run: coverage3 combine /tmp/u37/ml.dat
         shell: bash
       - name: Upload to Coveralls
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 100
-target-version = ['py36', 'py37', 'py38', 'py39']
+target-version = ['py36', 'py37', 'py38', 'py39', 'py310']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [tool.black]
 line-length = 100
-target-version = ['py36', 'py37', 'py38', 'py39', 'py310']
+target-version = ['py37', 'py38', 'py39', 'py310']

--- a/releasenotes/notes/add-python310-support-b2a9435d27a4164f.yaml
+++ b/releasenotes/notes/add-python310-support-b2a9435d27a4164f.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    Added support for running with Python 3.10. 
+    At the the time of the release, Torch didn't have a python 3.10 version.

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -60,6 +60,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Scientific/Engineering"
     ],
     keywords='qiskit sdk quantum machine learning ml',
@@ -68,7 +69,7 @@ setuptools.setup(
     include_package_data=True,
     python_requires=">=3.7",
     extras_require={
-        'torch': ["torch"],
+        'torch': ["torch; python_version < '3.10'"],
         'sparse': ["sparse"],
     },
     zip_safe=False

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 2.1
-envlist = py37, py38, py39, lint
+envlist = py37, py38, py39, py310, lint
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Following Qiskit/qiskit-terra#7102


### Details and comments
There isn't torch for python 3.10 yet. Since the tutorials use torch, I am keeping them running in the CI under python 3.7 and python 3.8 as before.

IMPORTANT:
Terra is backporting this. Once they release it to pypi, I will backport it as well. Do not backport before they release otherwise it will fail. The stable CI gets Terra from Pypi.

