### PR TITLE
Fix Ad Hoc dataset

### DIFF
--- a/qiskit_machine_learning/datasets/ad_hoc.py
+++ b/qiskit_machine_learning/datasets/ad_hoc.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2021.
+# (C) Copyright IBM 2018, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/datasets/ad_hoc.py
+++ b/qiskit_machine_learning/datasets/ad_hoc.py
@@ -40,6 +40,8 @@ def ad_hoc_data(
         count = 100
     elif n == 3:
         count = 20  # coarseness of data separation
+    else:
+        raise ValueError(f"Supported values of 'n' are 2 and 3 only, but {n} is provided.")
 
     label_train = np.zeros(2 * (training_size + test_size))
     sample_train = []
@@ -201,8 +203,8 @@ def ad_hoc_data(
                         + (np.pi - x_1) * (np.pi - x_3) * np.kron(np.kron(z_m, j_m), z_m)
                     )
                     u_u = scipy.linalg.expm(1j * phi)  # pylint: disable=no-member
-                    psi = np.asarray(u_u) * h_3 * np.asarray(u_u) * np.transpose(psi_0)
-                    temp = np.real(psi.conj().T * m_m * psi).item()
+                    psi = np.asarray(u_u) @ h_3 @ np.asarray(u_u) @ np.transpose(psi_0)
+                    temp = np.real(psi.conj().T @ m_m @ psi).item()
                     if temp > gap:
                         sample_total[n_1][n_2][n_3] = +1
                         sample_total_a.append([n_1, n_2, n_3])

--- a/releasenotes/notes/fix-adhoc-05105990dafba858.yaml
+++ b/releasenotes/notes/fix-adhoc-05105990dafba858.yaml
@@ -1,7 +1,6 @@
 ---
 fixes:
   - |
-    Fixes in Ad Hoc dataset:
-    - Fixed an ``ValueError`` when ``n=3`` is passed to ``ad_hoc_data``.
-    - When the value of ``n`` is not 2 or 3, a ``ValueError`` is raised with a message that the only
-      supported values of ``n`` are 2 and 3.
+    Fixes in Ad Hoc dataset. Fixed an ``ValueError`` when ``n=3`` is passed to ``ad_hoc_data``.
+    When the value of ``n`` is not 2 or 3, a ``ValueError`` is raised with a message that the only
+    supported values of ``n`` are 2 and 3.

--- a/releasenotes/notes/fix-adhoc-05105990dafba858.yaml
+++ b/releasenotes/notes/fix-adhoc-05105990dafba858.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes in Ad Hoc dataset:
+    - Fixed an ``ValueError`` when ``n=3`` is passed to ``ad_hoc_data``.
+    - When the value of ``n`` is not 2 or 3, a ``ValueError`` is raised with a message that the only
+      supported values of ``n`` are 2 and 3.

--- a/test/datasets/test_ad_hoc_data.py
+++ b/test/datasets/test_ad_hoc_data.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2021.
+# (C) Copyright IBM 2020, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/datasets/test_ad_hoc_data.py
+++ b/test/datasets/test_ad_hoc_data.py
@@ -13,28 +13,37 @@
 """ Test Ad Hoc Data """
 
 import unittest
+
 from test import QiskitMachineLearningTestCase
+
 import numpy as np
+from ddt import ddt, unpack, idata
+
 from qiskit_machine_learning.datasets import ad_hoc_data
 
 
+@ddt
 class TestAdHocData(QiskitMachineLearningTestCase):
     """Ad Hoc Data tests."""
 
-    def test_ad_hoc_data(self):
+    @idata(
+        ([2], [3]),
+    )
+    @unpack
+    def test_ad_hoc_data(self, num_features):
         """Ad Hoc Data test."""
 
         training_features, training_labels, _, test_labels = ad_hoc_data(
-            training_size=20, test_size=10, n=2, gap=0.3, plot_data=False, one_hot=False
+            training_size=20, test_size=10, n=num_features, gap=0.3, plot_data=False, one_hot=False
         )
-        np.testing.assert_array_equal(training_features.shape, (40, 2))
+        np.testing.assert_array_equal(training_features.shape, (40, num_features))
         np.testing.assert_array_equal(training_labels.shape, (40,))
         np.testing.assert_array_almost_equal(
             test_labels, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
         )
 
         _, _, _, test_labels = ad_hoc_data(
-            training_size=20, test_size=10, n=2, gap=0.3, plot_data=False, one_hot=True
+            training_size=20, test_size=10, n=num_features, gap=0.3, plot_data=False, one_hot=True
         )
 
         np.testing.assert_array_equal(test_labels.shape, (20, 2))
@@ -63,6 +72,15 @@ class TestAdHocData(QiskitMachineLearningTestCase):
                 [0, 1],
             ],
         )
+
+    @idata(
+        ([1], [4]),
+    )
+    @unpack
+    def test_wrong_params(self, num_features):
+        """Tests Ad Hoc Data with wrong parameters."""
+        with self.assertRaises(ValueError):
+            _, _, _, _ = ad_hoc_data(training_size=20, test_size=10, n=num_features, gap=0.3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixes in Ad Hoc dataset:

- Fixed an `ValueError` when `n=3` is passed to `ad_hoc_data`.
- When the value of `n` is not 2 or 3, a `ValueError` is raised with a message that the only
      supported values of `n` are 2 and 3.


### Details and comments
Fixes #278, #221.

