### PR TITLE
Pin Windows CI version to 2019

### DIFF
--- a/.github/actions/install-main-dependencies/action.yml
+++ b/.github/actions/install-main-dependencies/action.yml
@@ -28,7 +28,7 @@ runs:
           sudo apt-get -y install libspdlog-dev
           sudo apt-get -y install libmuparserx-dev
         fi
-        if [ "${{ inputs.os }}" == "windows-latest" ]; then
+        if [ "${{ inputs.os }}" == "windows-2019" ]; then
           git clone https://github.com/Qiskit/qiskit-aer.git /tmp/qiskit-aer
           pushd /tmp/qiskit-aer
           python setup.py bdist_wheel -- -G 'Visual Studio 16 2019'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,9 +109,9 @@ jobs:
             python-version: 3.8
           - os: macos-latest
             python-version: '3.10'
-          - os: windows-latest
+          - os: windows-2019
             python-version: 3.8
-          - os: windows-latest
+          - os: windows-2019
             python-version: '3.10'
     steps:
       - uses: actions/checkout@v2
@@ -273,11 +273,11 @@ jobs:
           path: /tmp/m310
       - uses: actions/download-artifact@v2
         with:
-          name: windows-latest-3.8
+          name: windows-2019-3.8
           path: /tmp/w38
       - uses: actions/download-artifact@v2
         with:
-          name: windows-latest-3.10
+          name: windows-2019-3.10
           path: /tmp/w310
       - name: Install Dependencies
         run: pip install -U coverage coveralls diff-cover


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Recent CI release of Windows 2022 breaks Terra main build. Pinning to previous 2019 for now.


### Details and comments


