### PR TITLE
[Stable] Fix deprecation of UniformDistribution in the QGAN tutorial

### DIFF
--- a/docs/tutorials/04_qgans_for_loading_random_distributions.ipynb
+++ b/docs/tutorials/04_qgans_for_loading_random_distributions.ipynb
@@ -36,7 +36,7 @@
     "%matplotlib inline\n",
     "\n",
     "from qiskit import QuantumRegister, QuantumCircuit, BasicAer\n",
-    "from qiskit.circuit.library import TwoLocal, UniformDistribution\n",
+    "from qiskit.circuit.library import TwoLocal\n",
     "\n",
     "from qiskit.utils import QuantumInstance, algorithm_globals\n",
     "from qiskit_machine_learning.algorithms import NumPyDiscriminator, QGAN\n",
@@ -116,8 +116,10 @@
     "entangler_map = [[0, 1]]\n",
     "\n",
     "\n",
-    "# Set an initial state for the generator circuit\n",
-    "init_dist = UniformDistribution(sum(num_qubits))\n",
+    "# Set an initial state for the generator circuit as a uniform distribution\n",
+    "# This corresponds to applying Hadamard gates on all qubits\n",
+    "init_dist = QuantumCircuit(sum(num_qubits))\n",
+    "init_dist.h(init_dist.qubits)\n",
     "\n",
     "# Set the ansatz circuit\n",
     "ansatz = TwoLocal(int(np.sum(num_qubits)), \"ry\", \"cz\", entanglement=entangler_map, reps=1)\n",
@@ -381,7 +383,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.7.9"
   },
   "varInspector": {
    "cols": {

--- a/qiskit_machine_learning/algorithms/classifiers/pegasos_qsvc.py
+++ b/qiskit_machine_learning/algorithms/classifiers/pegasos_qsvc.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -273,7 +273,7 @@ class PegasosQSVC(SVC):
             else:
                 kernel_value = X[index, j]
 
-            value += (
+            value += (  # type: ignore
                 # alpha weights the contribution of the associated datum
                 self._alphas[j]
                 # the class membership labels have to be in {-1, +1}

--- a/test/datasets/test_digits.py
+++ b/test/datasets/test_digits.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2021.
+# (C) Copyright IBM 2020, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -33,11 +33,11 @@ class TestDigits(QiskitMachineLearningTestCase):
             training_size=20, test_size=10, n=2, plot_data=False
         )
 
-        np.testing.assert_almost_equal(ref_data["training_features"], training_features, 4)
-        np.testing.assert_almost_equal(ref_data["training_labels"], training_labels, 4)
+        np.testing.assert_almost_equal(ref_data["training_features"], training_features, 2)
+        np.testing.assert_almost_equal(ref_data["training_labels"], training_labels, 2)
 
-        np.testing.assert_almost_equal(ref_data["test_features"], test_features, 3)
-        np.testing.assert_almost_equal(ref_data["test_labels"], test_labels, 4)
+        np.testing.assert_almost_equal(ref_data["test_features"], test_features, 2)
+        np.testing.assert_almost_equal(ref_data["test_labels"], test_labels, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Terra probability_distributions has been deprecated for a while and has been removed from Terra: Qiskit/qiskit-terra#7562


### Details and comments
Since modelling a uniform distribution is relatively easy a reference to the UniformDistribution is removed, replaced with a circuit and a few comment are added.

Even though stable Terra still contains the UniformDistribution class, it has been deprecated for a long time and the tutorial in stable should have been fixed already to remove any deprecation warnings.

