### PR TITLE
Use bound_pass_manager in CircuitQNN

### DIFF
--- a/qiskit_machine_learning/algorithms/classifiers/vqc.py
+++ b/qiskit_machine_learning/algorithms/classifiers/vqc.py
@@ -40,7 +40,6 @@ class VQC(NeuralNetworkClassifier):
         quantum_instance: QuantumInstance = None,
         initial_point: np.ndarray = None,
         callback: Optional[Callable[[np.ndarray, float], None]] = None,
-        cache_transpilation: bool = True,
     ) -> None:
         """
         Args:
@@ -118,7 +117,6 @@ class VQC(NeuralNetworkClassifier):
             output_shape=2,
             quantum_instance=quantum_instance,
             input_gradients=False,
-            cache_transpilation=cache_transpilation,
         )
 
         super().__init__(

--- a/qiskit_machine_learning/algorithms/classifiers/vqc.py
+++ b/qiskit_machine_learning/algorithms/classifiers/vqc.py
@@ -40,6 +40,7 @@ class VQC(NeuralNetworkClassifier):
         quantum_instance: QuantumInstance = None,
         initial_point: np.ndarray = None,
         callback: Optional[Callable[[np.ndarray, float], None]] = None,
+        cache_transpilation: bool = True,
     ) -> None:
         """
         Args:
@@ -117,6 +118,7 @@ class VQC(NeuralNetworkClassifier):
             output_shape=2,
             quantum_instance=quantum_instance,
             input_gradients=False,
+            cache_transpilation=cache_transpilation,
         )
 
         super().__init__(

--- a/qiskit_machine_learning/neural_networks/circuit_qnn.py
+++ b/qiskit_machine_learning/neural_networks/circuit_qnn.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2021.
+# (C) Copyright IBM 2020, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/neural_networks/circuit_qnn.py
+++ b/qiskit_machine_learning/neural_networks/circuit_qnn.py
@@ -208,7 +208,7 @@ class CircuitQNN(SamplingNeuralNetwork):
                         "determined as 2^num_qubits."
                     )
 
-                output_shape_ = (2 ** self._circuit.num_qubits,)
+                output_shape_ = (2**self._circuit.num_qubits,)
 
         # final validation
         output_shape_ = self._validate_output_shape(output_shape_)
@@ -250,8 +250,10 @@ class CircuitQNN(SamplingNeuralNetwork):
         measurements or not depending on the type of backend used.
         """
         self._set_quantum_instance(
-            quantum_instance, self._original_output_shape, self._original_interpret,
-            self._cache_transpilation
+            quantum_instance,
+            self._original_output_shape,
+            self._original_interpret,
+            self._cache_transpilation,
         )
 
     def _set_quantum_instance(

--- a/qiskit_machine_learning/neural_networks/circuit_qnn.py
+++ b/qiskit_machine_learning/neural_networks/circuit_qnn.py
@@ -62,16 +62,11 @@ class CircuitQNN(SamplingNeuralNetwork):
         gradient: Gradient = None,
         quantum_instance: Optional[Union[QuantumInstance, BaseBackend, Backend]] = None,
         input_gradients: bool = False,
+        cache_transpilation: bool = True,
     ) -> None:
         """
         Args:
             circuit: The parametrized quantum circuit that generates the samples of this network.
-                There will be an attempt to transpile this circuit and cache the transpiled circuit
-                for subsequent usages by the network. If for some reasons the circuit can't be
-                transpiled, e.g. it originates from
-                :class:`~qiskit_machine_learning.circuit.library.RawFeatureVector`, the circuit
-                will be transpiled every time it is required to be executed and only when all
-                parameters are bound. This may impact overall performance on the network.
             input_params: The parameters of the circuit corresponding to the input.
             weight_params: The parameters of the circuit corresponding to the trainable weights.
             sparse: Returns whether the output is sparse or not.
@@ -99,6 +94,12 @@ class CircuitQNN(SamplingNeuralNetwork):
             input_gradients: Determines whether to compute gradients with respect to input data.
                 Note that this parameter is ``False`` by default, and must be explicitly set to
                 ``True`` for a proper gradient computation when using ``TorchConnector``.
+            cache_transpilation: If set to True, there will be an attempt to transpile this circuit
+                and cache the transpiled circuit for subsequent usages by the network. If set to
+                False or if for some reasons the circuit can't be transpiled (e.g. it originates
+                from :class:`~qiskit_machine_learning.circuit.library.RawFeatureVector`) the circuit
+                will be transpiled every time it is required to be executed and only when all
+                parameters are bound. This may impact overall performance on the network.
         Raises:
             QiskitMachineLearningError: if ``interpret`` is passed without ``output_shape``.
 
@@ -119,13 +120,14 @@ class CircuitQNN(SamplingNeuralNetwork):
         # next line is required by pylint only
         self._interpret = interpret
         self._original_interpret = interpret
+        self._cache_transpilation = cache_transpilation
 
         # we need this property in _set_quantum_instance despite it is initialized
         # in the super class later on, review of SamplingNN is required.
         self._sampling = sampling
 
         # set quantum instance and derive target output_shape and interpret
-        self._set_quantum_instance(quantum_instance, output_shape, interpret)
+        self._set_quantum_instance(quantum_instance, output_shape, interpret, cache_transpilation)
 
         # init super class
         super().__init__(
@@ -248,7 +250,8 @@ class CircuitQNN(SamplingNeuralNetwork):
         measurements or not depending on the type of backend used.
         """
         self._set_quantum_instance(
-            quantum_instance, self._original_output_shape, self._original_interpret
+            quantum_instance, self._original_output_shape, self._original_interpret,
+            self._cache_transpilation
         )
 
     def _set_quantum_instance(
@@ -256,6 +259,7 @@ class CircuitQNN(SamplingNeuralNetwork):
         quantum_instance: Optional[Union[QuantumInstance, BaseBackend, Backend]],
         output_shape: Union[int, Tuple[int, ...]],
         interpret: Optional[Callable[[int], Union[int, Tuple[int, ...]]]],
+        cache_transpilation: bool,
     ) -> None:
         """
         Internal method to set a quantum instance and compute/initialize internal properties such
@@ -266,6 +270,7 @@ class CircuitQNN(SamplingNeuralNetwork):
             output_shape: An output shape of the custom interpretation.
             interpret: A callable that maps the measured integer to another unsigned integer or
                 tuple of unsigned integers.
+            cache_transpilation: Whether to store transpiled circuit.
         """
         if isinstance(quantum_instance, (BaseBackend, Backend)):
             quantum_instance = QuantumInstance(quantum_instance)
@@ -286,12 +291,15 @@ class CircuitQNN(SamplingNeuralNetwork):
             self._sampler = CircuitSampler(self._quantum_instance, param_qobj=False, caching="all")
 
             # transpile the QNN circuit
-            try:
-                self._circuit = self._quantum_instance.transpile(self._circuit)[0]
-                self._circuit_transpiled = True
-            except QiskitError:
-                # likely it is caused by RawFeatureVector, we just ignore this error and
-                # transpile circuits when it is required.
+            if cache_transpilation:
+                try:
+                    self._circuit = self._quantum_instance.transpile(self._circuit)[0]
+                    self._circuit_transpiled = True
+                except QiskitError:
+                    # likely it is caused by RawFeatureVector, we just ignore this error and
+                    # transpile circuits when it is required.
+                    self._circuit_transpiled = False
+            else:
                 self._circuit_transpiled = False
         else:
             self._output_shape = output_shape

--- a/qiskit_machine_learning/neural_networks/circuit_qnn.py
+++ b/qiskit_machine_learning/neural_networks/circuit_qnn.py
@@ -287,7 +287,9 @@ class CircuitQNN(SamplingNeuralNetwork):
 
             # transpile the QNN circuit
             try:
-                self._circuit = self._quantum_instance.transpile(self._circuit)[0]
+                self._circuit = self._quantum_instance.transpile(
+                    self._circuit, pass_manager=self._quantum_instance.unbound_pass_manager
+                )[0]
                 self._circuit_transpiled = True
             except QiskitError:
                 # likely it is caused by RawFeatureVector, we just ignore this error and

--- a/qiskit_machine_learning/neural_networks/circuit_qnn.py
+++ b/qiskit_machine_learning/neural_networks/circuit_qnn.py
@@ -360,7 +360,9 @@ class CircuitQNN(SamplingNeuralNetwork):
             circuits.append(self._circuit.bind_parameters(param_values))
 
         if self._quantum_instance.bound_pass_manager:
-            circuits = self._quantum_instance(circuits, self._quantum_instance.bound_pass_manager)
+            circuits = self._quantum_instance.transpile(
+                circuits, pass_manager=self._quantum_instance.bound_pass_manager
+            )
 
         result = self._quantum_instance.execute(circuits, had_transpiled=self._circuit_transpiled)
         # set the memory setting back
@@ -397,7 +399,9 @@ class CircuitQNN(SamplingNeuralNetwork):
             circuits.append(self._circuit.bind_parameters(param_values))
 
         if self._quantum_instance.bound_pass_manager:
-            circuits = self._quantum_instance(circuits, self._quantum_instance.bound_pass_manager)
+            circuits = self._quantum_instance.transpile(
+                circuits, pass_manager=self._quantum_instance.bound_pass_manager
+            )
 
         result = self._quantum_instance.execute(circuits, had_transpiled=self._circuit_transpiled)
         # initialize probabilities

--- a/releasenotes/notes/use-bound-pass-manager-in-circuitqnn-20c60effedb70d76.yaml
+++ b/releasenotes/notes/use-bound-pass-manager-in-circuitqnn-20c60effedb70d76.yaml
@@ -1,6 +1,6 @@
 ---
 features:
   - |
-    Fix in ``CircuitQNN`` that ensures unbound_pass_manager is called when caching
+    Added a new feature in ``CircuitQNN`` that ensures unbound_pass_manager is called when caching
     the QNN circuit and that ``bound_pass_manager`` is called when QNN parameters
     are assigned.

--- a/releasenotes/notes/use-bound-pass-manager-in-circuitqnn-20c60effedb70d76.yaml
+++ b/releasenotes/notes/use-bound-pass-manager-in-circuitqnn-20c60effedb70d76.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix in ``CircuitQNN`` that ensures unbound_pass_manager is called when caching
+    the QNN circuit and that ``bound_pass_manager`` is called when QNN parameters
+    are assigned.

--- a/releasenotes/notes/use-bound-pass-manager-in-circuitqnn-20c60effedb70d76.yaml
+++ b/releasenotes/notes/use-bound-pass-manager-in-circuitqnn-20c60effedb70d76.yaml
@@ -1,5 +1,5 @@
 ---
-fixes:
+features:
   - |
     Fix in ``CircuitQNN`` that ensures unbound_pass_manager is called when caching
     the QNN circuit and that ``bound_pass_manager`` is called when QNN parameters

--- a/test/neural_networks/test_circuit_qnn.py
+++ b/test/neural_networks/test_circuit_qnn.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2021.
+# (C) Copyright IBM 2018, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/neural_networks/test_circuit_qnn.py
+++ b/test/neural_networks/test_circuit_qnn.py
@@ -26,11 +26,7 @@ from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.library import RealAmplitudes, ZZFeatureMap
 from qiskit.utils import QuantumInstance, algorithm_globals
 from qiskit.exceptions import MissingOptionalLibraryError
-from qiskit.compiler.transpiler import PassManager, PassManagerConfig, level_3_pass_manager
-from qiskit.transpiler.passes.basis import BasisTranslator, UnrollCustomDefinitions
-from qiskit.circuit.library.standard_gates.equivalence_library import (
-    StandardEquivalenceLibrary as std_eqlib,
-)
+from qiskit.compiler.transpiler import PassManagerConfig, level_1_pass_manager, level_2_pass_manager
 from qiskit.test.mock import FakeToronto
 
 from qiskit_machine_learning import QiskitMachineLearningError
@@ -68,13 +64,8 @@ class TestCircuitQNN(QiskitMachineLearningTestCase):
             shots=100,
             seed_simulator=algorithm_globals.random_seed,
             seed_transpiler=algorithm_globals.random_seed,
-            pass_manager=level_3_pass_manager(PassManagerConfig.from_backend(FakeToronto())),
-            bound_pass_manager=PassManager(
-                [
-                    UnrollCustomDefinitions(std_eqlib, cz_basis),
-                    BasisTranslator(std_eqlib, cz_basis),
-                ]
-            ),
+            pass_manager=level_1_pass_manager(PassManagerConfig.from_backend(FakeToronto())),
+            bound_pass_manager=level_2_pass_manager(PassManagerConfig.from_backend(FakeToronto())),
         )
 
         # define feature map and ansatz

--- a/test/neural_networks/test_circuit_qnn.py
+++ b/test/neural_networks/test_circuit_qnn.py
@@ -62,7 +62,7 @@ class TestCircuitQNN(QiskitMachineLearningTestCase):
             seed_simulator=algorithm_globals.random_seed,
             seed_transpiler=algorithm_globals.random_seed,
         )
-        rzx_basis = ["rzx", "rz", "x", "sx"]
+        cz_basis = ["cz", "rz", "x", "sx"]
         self.quantum_instance_pm = QuantumInstance(
             AerSimulator(),
             shots=100,
@@ -71,8 +71,8 @@ class TestCircuitQNN(QiskitMachineLearningTestCase):
             pass_manager=level_3_pass_manager(PassManagerConfig.from_backend(FakeToronto())),
             bound_pass_manager=PassManager(
                 [
-                    UnrollCustomDefinitions(std_eqlib, rzx_basis),
-                    BasisTranslator(std_eqlib, rzx_basis),
+                    UnrollCustomDefinitions(std_eqlib, cz_basis),
+                    BasisTranslator(std_eqlib, cz_basis),
                 ]
             ),
         )

--- a/test/neural_networks/test_circuit_qnn.py
+++ b/test/neural_networks/test_circuit_qnn.py
@@ -58,7 +58,6 @@ class TestCircuitQNN(QiskitMachineLearningTestCase):
             seed_simulator=algorithm_globals.random_seed,
             seed_transpiler=algorithm_globals.random_seed,
         )
-        cz_basis = ["cz", "rz", "x", "sx"]
         self.quantum_instance_pm = QuantumInstance(
             AerSimulator(),
             shots=100,

--- a/test/neural_networks/test_circuit_qnn.py
+++ b/test/neural_networks/test_circuit_qnn.py
@@ -26,6 +26,12 @@ from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.library import RealAmplitudes, ZZFeatureMap
 from qiskit.utils import QuantumInstance, algorithm_globals
 from qiskit.exceptions import MissingOptionalLibraryError
+from qiskit.compiler.transpiler import PassManager, PassManagerConfig, level_3_pass_manager
+from qiskit.transpiler.passes.basis import BasisTranslator, UnrollCustomDefinitions
+from qiskit.circuit.library.standard_gates.equivalence_library import (
+    StandardEquivalenceLibrary as std_eqlib,
+)
+from qiskit.test.mock import FakeToronto
 
 from qiskit_machine_learning import QiskitMachineLearningError
 from qiskit_machine_learning.neural_networks import CircuitQNN
@@ -33,6 +39,8 @@ from qiskit_machine_learning.neural_networks import CircuitQNN
 QASM = "qasm"
 
 STATEVECTOR = "statevector"
+
+CUSTOM_PASS_MANAGERS = "custom_pass_managers"
 
 
 @ddt
@@ -53,6 +61,20 @@ class TestCircuitQNN(QiskitMachineLearningTestCase):
             shots=100,
             seed_simulator=algorithm_globals.random_seed,
             seed_transpiler=algorithm_globals.random_seed,
+        )
+        rzx_basis = ["rzx", "rz", "x", "sx"]
+        self.quantum_instance_pm = QuantumInstance(
+            AerSimulator(),
+            shots=100,
+            seed_simulator=algorithm_globals.random_seed,
+            seed_transpiler=algorithm_globals.random_seed,
+            pass_manager=level_3_pass_manager(PassManagerConfig.from_backend(FakeToronto())),
+            bound_pass_manager=PassManager(
+                [
+                    UnrollCustomDefinitions(std_eqlib, rzx_basis),
+                    BasisTranslator(std_eqlib, rzx_basis),
+                ]
+            ),
         )
 
         # define feature map and ansatz
@@ -93,6 +115,8 @@ class TestCircuitQNN(QiskitMachineLearningTestCase):
             quantum_instance = self.quantum_instance_sv
         elif quantum_instance_type == QASM:
             quantum_instance = self.quantum_instance_qasm
+        elif quantum_instance_type == CUSTOM_PASS_MANAGERS:
+            quantum_instance = self.quantum_instance_pm
         else:
             quantum_instance = None
 
@@ -204,6 +228,12 @@ class TestCircuitQNN(QiskitMachineLearningTestCase):
         (True, True, QASM, 1, 2),
         (True, True, QASM, 2, 1),
         (True, True, QASM, 2, 2),
+        (True, True, CUSTOM_PASS_MANAGERS, 0, 1),
+        (True, True, CUSTOM_PASS_MANAGERS, 0, 2),
+        (True, True, CUSTOM_PASS_MANAGERS, 1, 1),
+        (True, True, CUSTOM_PASS_MANAGERS, 1, 2),
+        (True, True, CUSTOM_PASS_MANAGERS, 2, 1),
+        (True, True, CUSTOM_PASS_MANAGERS, 2, 2),
         (True, False, STATEVECTOR, 0, 1),
         (True, False, STATEVECTOR, 0, 2),
         (True, False, STATEVECTOR, 1, 1),
@@ -216,6 +246,12 @@ class TestCircuitQNN(QiskitMachineLearningTestCase):
         (True, False, QASM, 1, 2),
         (True, False, QASM, 2, 1),
         (True, False, QASM, 2, 2),
+        (True, False, CUSTOM_PASS_MANAGERS, 0, 1),
+        (True, False, CUSTOM_PASS_MANAGERS, 0, 2),
+        (True, False, CUSTOM_PASS_MANAGERS, 1, 1),
+        (True, False, CUSTOM_PASS_MANAGERS, 1, 2),
+        (True, False, CUSTOM_PASS_MANAGERS, 2, 1),
+        (True, False, CUSTOM_PASS_MANAGERS, 2, 2),
         (False, True, STATEVECTOR, 0, 1),
         (False, True, STATEVECTOR, 0, 2),
         (False, True, STATEVECTOR, 1, 1),
@@ -228,6 +264,12 @@ class TestCircuitQNN(QiskitMachineLearningTestCase):
         (False, True, QASM, 1, 2),
         (False, True, QASM, 2, 1),
         (False, True, QASM, 2, 2),
+        (False, True, CUSTOM_PASS_MANAGERS, 0, 1),
+        (False, True, CUSTOM_PASS_MANAGERS, 0, 2),
+        (False, True, CUSTOM_PASS_MANAGERS, 1, 1),
+        (False, True, CUSTOM_PASS_MANAGERS, 1, 2),
+        (False, True, CUSTOM_PASS_MANAGERS, 2, 1),
+        (False, True, CUSTOM_PASS_MANAGERS, 2, 2),
         (False, False, STATEVECTOR, 0, 1),
         (False, False, STATEVECTOR, 0, 2),
         (False, False, STATEVECTOR, 1, 1),
@@ -240,6 +282,12 @@ class TestCircuitQNN(QiskitMachineLearningTestCase):
         (False, False, QASM, 1, 2),
         (False, False, QASM, 2, 1),
         (False, False, QASM, 2, 2),
+        (False, False, CUSTOM_PASS_MANAGERS, 0, 1),
+        (False, False, CUSTOM_PASS_MANAGERS, 0, 2),
+        (False, False, CUSTOM_PASS_MANAGERS, 1, 1),
+        (False, False, CUSTOM_PASS_MANAGERS, 1, 2),
+        (False, False, CUSTOM_PASS_MANAGERS, 2, 1),
+        (False, False, CUSTOM_PASS_MANAGERS, 2, 2),
     )
     @requires_extra_library
     def test_circuit_qnn(self, config):
@@ -341,6 +389,13 @@ class TestCircuitQNN(QiskitMachineLearningTestCase):
         (True, True, QASM, 1, 1),
         (True, True, QASM, 1, 2),
         (True, True, QASM, 2, 1),
+        (True, True, QASM, 2, 2),
+        (True, True, CUSTOM_PASS_MANAGERS, 0, 1),
+        (True, True, CUSTOM_PASS_MANAGERS, 0, 2),
+        (True, True, CUSTOM_PASS_MANAGERS, 1, 1),
+        (True, True, CUSTOM_PASS_MANAGERS, 1, 2),
+        (True, True, CUSTOM_PASS_MANAGERS, 2, 1),
+        (True, True, CUSTOM_PASS_MANAGERS, 2, 2),
         (True, False, STATEVECTOR, 0, 1),
         (True, False, STATEVECTOR, 0, 2),
         (True, False, STATEVECTOR, 1, 1),
@@ -353,6 +408,12 @@ class TestCircuitQNN(QiskitMachineLearningTestCase):
         (True, False, QASM, 1, 2),
         (True, False, QASM, 2, 1),
         (True, False, QASM, 2, 2),
+        (True, False, CUSTOM_PASS_MANAGERS, 0, 1),
+        (True, False, CUSTOM_PASS_MANAGERS, 0, 2),
+        (True, False, CUSTOM_PASS_MANAGERS, 1, 1),
+        (True, False, CUSTOM_PASS_MANAGERS, 1, 2),
+        (True, False, CUSTOM_PASS_MANAGERS, 2, 1),
+        (True, False, CUSTOM_PASS_MANAGERS, 2, 2),
         (False, True, STATEVECTOR, 0, 1),
         (False, True, STATEVECTOR, 0, 2),
         (False, True, STATEVECTOR, 1, 1),
@@ -365,6 +426,12 @@ class TestCircuitQNN(QiskitMachineLearningTestCase):
         (False, True, QASM, 1, 2),
         (False, True, QASM, 2, 1),
         (False, True, QASM, 2, 2),
+        (False, True, CUSTOM_PASS_MANAGERS, 0, 1),
+        (False, True, CUSTOM_PASS_MANAGERS, 0, 2),
+        (False, True, CUSTOM_PASS_MANAGERS, 1, 1),
+        (False, True, CUSTOM_PASS_MANAGERS, 1, 2),
+        (False, True, CUSTOM_PASS_MANAGERS, 2, 1),
+        (False, True, CUSTOM_PASS_MANAGERS, 2, 2),
         (False, False, STATEVECTOR, 0, 1),
         (False, False, STATEVECTOR, 0, 2),
         (False, False, STATEVECTOR, 1, 1),
@@ -377,6 +444,12 @@ class TestCircuitQNN(QiskitMachineLearningTestCase):
         (False, False, QASM, 1, 2),
         (False, False, QASM, 2, 1),
         (False, False, QASM, 2, 2),
+        (False, False, CUSTOM_PASS_MANAGERS, 0, 1),
+        (False, False, CUSTOM_PASS_MANAGERS, 0, 2),
+        (False, False, CUSTOM_PASS_MANAGERS, 1, 1),
+        (False, False, CUSTOM_PASS_MANAGERS, 1, 2),
+        (False, False, CUSTOM_PASS_MANAGERS, 2, 1),
+        (False, False, CUSTOM_PASS_MANAGERS, 2, 2),
     )
     @requires_extra_library
     def test_no_quantum_instance(self, config):
@@ -403,6 +476,8 @@ class TestCircuitQNN(QiskitMachineLearningTestCase):
             quantum_instance = self.quantum_instance_sv
         elif quantum_instance_type == QASM:
             quantum_instance = self.quantum_instance_qasm
+        elif quantum_instance_type == CUSTOM_PASS_MANAGERS:
+            quantum_instance = self.quantum_instance_pm
         else:
             # must never happen
             quantum_instance = None


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR ensures `bound_pass_manager` is called when executing bound QNN circuits.

### Details and comments
N/A
