### PR TITLE
Batch computation of gradients in QNNs

### DIFF
--- a/qiskit_machine_learning/neural_networks/circuit_qnn.py
+++ b/qiskit_machine_learning/neural_networks/circuit_qnn.py
@@ -36,7 +36,7 @@ from scipy.sparse import coo_matrix
 
 from qiskit import QuantumCircuit
 from qiskit.circuit import Parameter
-from qiskit.opflow import Gradient, CircuitSampler, StateFn, OpflowError
+from qiskit.opflow import Gradient, CircuitSampler, StateFn, OpflowError, OperatorBase
 from qiskit.providers import BaseBackend, Backend
 from qiskit.utils import QuantumInstance
 from qiskit.exceptions import MissingOptionalLibraryError
@@ -107,6 +107,8 @@ class CircuitQNN(SamplingNeuralNetwork):
         self._weight_params = list(weight_params or [])
         self._input_gradients = input_gradients
         sparse = False if sampling else sparse
+        if sparse:
+            self._check_sparse_installed()
 
         # copy circuit and add measurements in case non are given
         # TODO: need to be able to handle partial measurements! (partial trace...)
@@ -145,7 +147,7 @@ class CircuitQNN(SamplingNeuralNetwork):
         self._construct_gradient_circuit()
 
     def _construct_gradient_circuit(self):
-        self._gradient_circuit: QuantumCircuit = None
+        self._gradient_circuit: OperatorBase = None
         try:
             # todo: avoid copying the circuit
             grad_circuit = self._original_circuit.copy()
@@ -206,7 +208,7 @@ class CircuitQNN(SamplingNeuralNetwork):
                         "determined as 2^num_qubits."
                     )
 
-                output_shape_ = (2 ** self._circuit.num_qubits,)
+                output_shape_ = (2**self._circuit.num_qubits,)
 
         # final validation
         output_shape_ = self._validate_output_shape(output_shape_)
@@ -336,9 +338,7 @@ class CircuitQNN(SamplingNeuralNetwork):
     def _sample(
         self, input_data: Optional[np.ndarray], weights: Optional[np.ndarray]
     ) -> np.ndarray:
-
-        if self._quantum_instance is None:
-            raise QiskitMachineLearningError("Sampling requires a quantum instance!")
+        self._check_quantum_instance("samples")
 
         if self._quantum_instance.is_statevector:
             raise QiskitMachineLearningError("Sampling does not work with statevector simulator!")
@@ -348,9 +348,9 @@ class CircuitQNN(SamplingNeuralNetwork):
         self._quantum_instance.backend_options["memory"] = True
 
         circuits = []
-        # iterate over rows, each row is an element of a batch
-        rows = input_data.shape[0]
-        for i in range(rows):
+        # iterate over samples, each sample is an element of a batch
+        num_samples = input_data.shape[0]
+        for i in range(num_samples):
             param_values = {
                 input_param: input_data[i, j] for j, input_param in enumerate(self._input_params)
             }
@@ -364,7 +364,7 @@ class CircuitQNN(SamplingNeuralNetwork):
         self._quantum_instance.backend_options["memory"] = orig_memory
 
         # return samples
-        samples = np.zeros((rows, *self._output_shape))
+        samples = np.zeros((num_samples, *self._output_shape))
         # collect them from all executed circuits
         for i, circuit in enumerate(circuits):
             memory = result.get_memory(circuit)
@@ -375,16 +375,12 @@ class CircuitQNN(SamplingNeuralNetwork):
     def _probabilities(
         self, input_data: Optional[np.ndarray], weights: Optional[np.ndarray]
     ) -> Union[np.ndarray, SparseArray]:
-
-        if self._quantum_instance is None:
-            raise QiskitMachineLearningError(
-                "Evaluation of probabilities requires a quantum instance!"
-            )
+        self._check_quantum_instance("probabilities")
 
         # evaluate operator
         circuits = []
-        rows = input_data.shape[0]
-        for i in range(rows):
+        num_samples = input_data.shape[0]
+        for i in range(num_samples):
             param_values = {
                 input_param: input_data[i, j] for j, input_param in enumerate(self._input_params)
             }
@@ -396,15 +392,9 @@ class CircuitQNN(SamplingNeuralNetwork):
         result = self._quantum_instance.execute(circuits, had_transpiled=self._circuit_transpiled)
         # initialize probabilities
         if self._sparse:
-            if not _HAS_SPARSE:
-                raise MissingOptionalLibraryError(
-                    libname="sparse",
-                    name="DOK",
-                    pip_install="pip install 'qiskit-machine-learning[sparse]'",
-                )
-            prob = DOK((rows, *self._output_shape))
+            prob = DOK((num_samples, *self._output_shape))
         else:
-            prob = np.zeros((rows, *self._output_shape))
+            prob = np.zeros((num_samples, *self._output_shape))
 
         for i, circuit in enumerate(circuits):
             counts = result.get_counts(circuit)
@@ -426,50 +416,48 @@ class CircuitQNN(SamplingNeuralNetwork):
     def _probability_gradients(
         self, input_data: Optional[np.ndarray], weights: Optional[np.ndarray]
     ) -> Tuple[Union[np.ndarray, SparseArray], Union[np.ndarray, SparseArray]]:
-        self._check_quantum_instance()
+        self._check_quantum_instance("probability gradients")
 
         # check whether gradient circuit could be constructed
         if self._gradient_circuit is None:
             return None, None
 
-        # todo: rename to num_samples
-        rows = input_data.shape[0]
+        num_samples = input_data.shape[0]
 
         # initialize empty gradients
         input_grad = None  # by default we don't have data gradients
         if self._sparse:
-            if not _HAS_SPARSE:
-                raise MissingOptionalLibraryError(
-                    libname="sparse",
-                    name="DOK",
-                    pip_install="pip install 'qiskit-machine-learning[sparse]'",
-                )
             if self._input_gradients:
-                input_grad = DOK((rows, *self._output_shape, self._num_inputs))
-            weights_grad = DOK((rows, *self._output_shape, self._num_weights))
+                input_grad = DOK((num_samples, *self._output_shape, self._num_inputs))
+            weights_grad = DOK((num_samples, *self._output_shape, self._num_weights))
         else:
             if self._input_gradients:
-                input_grad = np.zeros((rows, *self._output_shape, self._num_inputs))
-            weights_grad = np.zeros((rows, *self._output_shape, self._num_weights))
+                input_grad = np.zeros((num_samples, *self._output_shape, self._num_inputs))
+            weights_grad = np.zeros((num_samples, *self._output_shape, self._num_weights))
 
         param_values = {
             input_param: input_data[:, j] for j, input_param in enumerate(self._input_params)
         }
         param_values.update(
-            {weight_param: np.full(rows, weights[j]) for j, weight_param in enumerate(self._weight_params)}
+            {
+                weight_param: np.full(num_samples, weights[j])
+                for j, weight_param in enumerate(self._weight_params)
+            }
         )
 
         converted_op = self._sampler.convert(self._gradient_circuit, param_values)
+        # if statement is a workaround for https://github.com/Qiskit/qiskit-terra/issues/7608
         if len(converted_op.parameters) >= 0:
             # create an list of parameter bindings, each element corresponds to a sample in the dataset
             param_bindings = [
-                {param: param_values[i] for param, param_values in param_values.items()} for i in range(rows)
+                {param: param_values[i] for param, param_values in param_values.items()}
+                for i in range(num_samples)
             ]
 
             grad = []
             # iterate over gradient vectors and bind the correct leftover parameters
             for g_i, param_i in zip(converted_op, param_bindings):
-                # bind or re-bind remaining values
+                # bind or re-bind remaining values and evaluate the gradient
                 grad.append(g_i.bind_parameters(param_i).eval())
         else:
             grad = converted_op.eval()
@@ -480,9 +468,9 @@ class CircuitQNN(SamplingNeuralNetwork):
             num_grad_vars = self._num_weights
 
         # construct gradients
-        for row in range(rows):
+        for sample in range(num_samples):
             for i in range(num_grad_vars):
-                coo_grad = coo_matrix(grad[row][i])  # this works for sparse and dense case
+                coo_grad = coo_matrix(grad[sample][i])  # this works for sparse and dense case
 
                 # get index for input or weights gradients
                 if self._input_gradients:
@@ -491,15 +479,14 @@ class CircuitQNN(SamplingNeuralNetwork):
                     grad_index = i
 
                 for _, k, val in zip(coo_grad.row, coo_grad.col, coo_grad.data):
-
                     # interpret integer and construct key
                     key = self._interpret(k)
                     if isinstance(key, Integral):
-                        key = (row, int(key), grad_index)
+                        key = (sample, int(key), grad_index)
                     else:
                         # if key is an array-type, cast to hashable tuple
                         key = tuple(cast(Iterable[int], key))
-                        key = (row, *key, grad_index)
+                        key = (sample, *key, grad_index)
 
                     # store value for inputs or weights gradients
                     if self._input_gradients:
@@ -519,8 +506,16 @@ class CircuitQNN(SamplingNeuralNetwork):
 
         return input_grad, weights_grad
 
-    def _check_quantum_instance(self):
+    def _check_sparse_installed(self):
+        if not _HAS_SPARSE:
+            raise MissingOptionalLibraryError(
+                libname="sparse",
+                name="DOK",
+                pip_install="pip install 'qiskit-machine-learning[sparse]'",
+            )
+
+    def _check_quantum_instance(self, feature: str):
         if self._quantum_instance is None:
             raise QiskitMachineLearningError(
-                "Evaluation of probability gradients requires a quantum instance!"
+                f"Evaluation of {feature} requires a quantum instance!"
             )

--- a/qiskit_machine_learning/neural_networks/circuit_qnn.py
+++ b/qiskit_machine_learning/neural_networks/circuit_qnn.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2021.
+# (C) Copyright IBM 2020, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -208,7 +208,7 @@ class CircuitQNN(SamplingNeuralNetwork):
                         "determined as 2^num_qubits."
                     )
 
-                output_shape_ = (2**self._circuit.num_qubits,)
+                output_shape_ = (2 ** self._circuit.num_qubits,)
 
         # final validation
         output_shape_ = self._validate_output_shape(output_shape_)
@@ -447,7 +447,7 @@ class CircuitQNN(SamplingNeuralNetwork):
 
         converted_op = self._sampler.convert(self._gradient_circuit, param_values)
         # if statement is a workaround for https://github.com/Qiskit/qiskit-terra/issues/7608
-        if len(converted_op.parameters) >= 0:
+        if len(converted_op.parameters) > 0:
             # create an list of parameter bindings, each element corresponds to a sample in the dataset
             param_bindings = [
                 {param: param_values[i] for param, param_values in param_values.items()}

--- a/qiskit_machine_learning/neural_networks/opflow_qnn.py
+++ b/qiskit_machine_learning/neural_networks/opflow_qnn.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2021.
+# (C) Copyright IBM 2020, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/neural_networks/opflow_qnn.py
+++ b/qiskit_machine_learning/neural_networks/opflow_qnn.py
@@ -13,7 +13,7 @@
 """An Opflow Quantum Neural Network that allows to use a parametrized opflow object as a
 neural network."""
 import logging
-from typing import List, Optional, Union, Tuple
+from typing import List, Optional, Union, Tuple, Dict
 
 import numpy as np
 from qiskit.circuit import Parameter
@@ -209,42 +209,95 @@ class OpflowQNN(NeuralNetwork):
         if self._gradient_operator is None:
             return None, None
 
-        # iterate over rows, each row is an element of a batch
-        batch_size = input_data.shape[0]
+        num_samples = input_data.shape[0]
         if self._input_gradients:
             num_params = self._num_inputs + self._num_weights
         else:
             num_params = self._num_weights
 
-        grad_all = np.zeros((batch_size, *self._output_shape, num_params))
+        param_values = {
+            input_param: input_data[:, j] for j, input_param in enumerate(self._input_params)
+        }
+        param_values.update(
+            {
+                weight_param: np.full(num_samples, weights[j])
+                for j, weight_param in enumerate(self._weight_params)
+            }
+        )
 
-        for row in range(batch_size):
-            # take i-th column as values for the i-th param in a batch
-            param_values = {p: input_data[row, j] for j, p in enumerate(self._input_params)}
-            param_values.update({p: weights[j] for j, p in enumerate(self._weight_params)})
-
-            # evaluate gradient over all parameters
-            if self._circuit_sampler:
-                grad = self._circuit_sampler.convert(self._gradient_operator, param_values)
-                # TODO: this should not be necessary and is a bug!
-                grad = grad.bind_parameters(param_values)
-                grad = np.real(grad.eval())
+        if self._circuit_sampler:
+            converted_op = self._circuit_sampler.convert(self._gradient_operator, param_values)
+            # if statement is a workaround for https://github.com/Qiskit/qiskit-terra/issues/7608
+            if len(converted_op.parameters) > 0:
+                # rebind the leftover parameters and evaluate the gradient
+                grad = self._evaluate_operator(converted_op, num_samples, param_values)
             else:
-                grad = self._gradient_operator.bind_parameters(param_values)
-                grad = np.real(grad.eval())
-            grad_all[row, :] = grad.transpose()
+                # all parameters are bound by CircuitSampler, so we evaluate the operator directly
+                grad = np.asarray(converted_op.eval())
+        else:
+            # we evaluate gradient operator for each sample separately, so we create a list of operators.
+            grad = self._evaluate_operator(
+                [self._gradient_operator] * num_samples, num_samples, param_values
+            )
+
+        grad = np.real(grad)
+
+        # this is another workaround to fix output shape of the invocation result of CircuitSampler
+        if self._output_shape == (1,):
+            # at least 3 dimensions: batch, output, num_parameters, but in this case we don't have
+            # output dimension, so we add a dimension that corresponds to the output
+            grad = grad.reshape((num_samples, 1, num_params))
+        else:
+            # swap last axis that corresponds to parameters and axes correspond to the output shape
+            last_axis = len(grad.shape) - 1
+            grad = grad.transpose([0, last_axis, *(range(1, last_axis))])
 
         # split into and return input and weights gradients
         if self._input_gradients:
-            input_grad = grad_all[:, :, : self._num_inputs].reshape(
+            input_grad = grad[:, :, : self._num_inputs].reshape(
                 -1, *self._output_shape, self._num_inputs
             )
 
-            weights_grad = grad_all[:, :, self._num_inputs :].reshape(
+            weights_grad = grad[:, :, self._num_inputs :].reshape(
                 -1, *self._output_shape, self._num_weights
             )
         else:
             input_grad = None
-            weights_grad = grad_all.reshape(-1, *self._output_shape, self._num_weights)
+            weights_grad = grad.reshape(-1, *self._output_shape, self._num_weights)
 
         return input_grad, weights_grad
+
+    def _evaluate_operator(
+        self,
+        operator: Union[OperatorBase, List[OperatorBase]],
+        num_samples: int,
+        param_values: Dict[Parameter, np.ndarray],
+    ) -> np.ndarray:
+        """
+        Evaluates an operator or a list of operators for the samples in the dataset. If an operator
+        is passed then it is considered as an iterable that has `num_samples` elements. Usually such
+        operators are obtained as an output from `CircuitSampler`. If a list of operators is passed
+        then each operator in this list is evaluated with a set of values/parameters corresponding
+        to the sample index in the `param_values` as the operator in the list.
+
+        Args:
+            operator: operator or list of operators to evaluate.
+            num_samples: a total number of samples
+            param_values: parameter values to use for operator evaluation.
+
+        Returns:
+            the result of operator evaluation as an array.
+        """
+        # create an list of parameter bindings, each element corresponds to a sample in the dataset
+        param_bindings = [
+            {param: param_values[i] for param, param_values in param_values.items()}
+            for i in range(num_samples)
+        ]
+
+        grad = []
+        # iterate over gradient vectors and bind the correct parameters
+        for oper_i, param_i in zip(operator, param_bindings):
+            # bind or re-bind remaining values and evaluate the gradient
+            grad.append(oper_i.bind_parameters(param_i).eval())
+
+        return np.asarray(grad)

--- a/releasenotes/notes/add-circuit-qnn-batch-grad-62be3eb762f0e82e.yaml
+++ b/releasenotes/notes/add-circuit-qnn-batch-grad-62be3eb762f0e82e.yaml
@@ -6,6 +6,6 @@ features:
     were aggregated into one output array. Thus, for each sample in a dataset at least one job was
     submitted. Now, gradients are computed for all samples in a dataset in one go by passing a
     list of values for a single parameter to ``CircuitSampler``. Therefore, a number of jobs
-    required for such computations is significantly reduced. This improvements may speed up
+    required for such computations is significantly reduced. This improvement may speed up
     training process in the cloud environment, where queue time for submitting a job may be
     a major contribution in the overall training time.

--- a/releasenotes/notes/add-circuit-qnn-batch-grad-62be3eb762f0e82e.yaml
+++ b/releasenotes/notes/add-circuit-qnn-batch-grad-62be3eb762f0e82e.yaml
@@ -1,0 +1,11 @@
+---
+features:
+  - |
+    In the previous releases at the backpropagation stage of ``CircuitQNN`` gradients were computed
+    for each sample in a dataset individually and then the obtained values were aggregated into
+    one output array. Thus, for each sample in a dataset at least one job was submitted. Now,
+    gradients are computed for all samples in a dataset in one go by passing a list of values for
+    a single parameter to ``CircuitSampler``. Therefore, a number of jobs required for such
+    computations is significantly reduced. This improvements may speed up training process in the
+    cloud environment, where queueing time for submitting a job may be a major contribution in the
+    overall training time.

--- a/releasenotes/notes/add-circuit-qnn-batch-grad-62be3eb762f0e82e.yaml
+++ b/releasenotes/notes/add-circuit-qnn-batch-grad-62be3eb762f0e82e.yaml
@@ -7,5 +7,5 @@ features:
     gradients are computed for all samples in a dataset in one go by passing a list of values for
     a single parameter to ``CircuitSampler``. Therefore, a number of jobs required for such
     computations is significantly reduced. This improvements may speed up training process in the
-    cloud environment, where queueing time for submitting a job may be a major contribution in the
+    cloud environment, where queue time for submitting a job may be a major contribution in the
     overall training time.

--- a/releasenotes/notes/add-circuit-qnn-batch-grad-62be3eb762f0e82e.yaml
+++ b/releasenotes/notes/add-circuit-qnn-batch-grad-62be3eb762f0e82e.yaml
@@ -1,11 +1,11 @@
 ---
 features:
   - |
-    In the previous releases at the backpropagation stage of ``CircuitQNN`` gradients were computed
-    for each sample in a dataset individually and then the obtained values were aggregated into
-    one output array. Thus, for each sample in a dataset at least one job was submitted. Now,
-    gradients are computed for all samples in a dataset in one go by passing a list of values for
-    a single parameter to ``CircuitSampler``. Therefore, a number of jobs required for such
-    computations is significantly reduced. This improvements may speed up training process in the
-    cloud environment, where queue time for submitting a job may be a major contribution in the
-    overall training time.
+    In the previous releases at the backpropagation stage of ``CircuitQNN`` and ``OpflowQNN``
+    gradients were computed for each sample in a dataset individually and then the obtained values
+    were aggregated into one output array. Thus, for each sample in a dataset at least one job was
+    submitted. Now, gradients are computed for all samples in a dataset in one go by passing a
+    list of values for a single parameter to ``CircuitSampler``. Therefore, a number of jobs
+    required for such computations is significantly reduced. This improvements may speed up
+    training process in the cloud environment, where queue time for submitting a job may be
+    a major contribution in the overall training time.

--- a/test/neural_networks/test_opflow_qnn.py
+++ b/test/neural_networks/test_opflow_qnn.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2021.
+# (C) Copyright IBM 2018, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/neural_networks/test_opflow_qnn.py
+++ b/test/neural_networks/test_opflow_qnn.py
@@ -53,6 +53,7 @@ class TestOpflowQNN(QiskitMachineLearningTestCase):
             seed_simulator=algorithm_globals.random_seed,
             seed_transpiler=algorithm_globals.random_seed,
         )
+        np.random.seed(algorithm_globals.random_seed)
 
     def validate_output_shape(self, qnn: OpflowQNN, test_data: List[np.ndarray]) -> None:
         """


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Currently gradients for a batch are evaluated one by one. Thus, for each sample in a dataset at least one job is submitted. It is possible to evaluate gradients for all samples in one go by passing a list of values to `CircuitSampler`. In this PR we make use of this batching feature to reduce a number of jobs required to compute gradients.


### Details and comments
There is a workaround in the code to overcome a problem(or a "feature"?) in `CircuitSampler`: https://github.com/Qiskit/qiskit-terra/issues/7608
There are a few refactorings as well to simplify the code.

