### PR TITLE
Fix quantum kernel trainer web docs

### DIFF
--- a/docs/apidocs/qiskit_machine_learning.kernels.algorithms.rst
+++ b/docs/apidocs/qiskit_machine_learning.kernels.algorithms.rst
@@ -1,0 +1,6 @@
+﻿.. _qiskit-machine-learning-kernels-algorithms:
+
+.. automodule:: qiskit_machine_learning.kernels.algorithms
+   :no-members:
+   :no-inherited-members:
+   :no-special-members:

--- a/qiskit_machine_learning/kernels/__init__.py
+++ b/qiskit_machine_learning/kernels/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/kernels/__init__.py
+++ b/qiskit_machine_learning/kernels/__init__.py
@@ -24,6 +24,13 @@ Quantum Kernels
 
    QuantumKernel
 
+Submodules
+==========
+
+.. autosummary::
+   :toctree:
+
+   algorithms
 """
 
 from .quantum_kernel import QuantumKernel

--- a/qiskit_machine_learning/kernels/algorithms/__init__.py
+++ b/qiskit_machine_learning/kernels/algorithms/__init__.py
@@ -15,7 +15,7 @@ Quantum Kernel Algorithms (:mod:`qiskit_machine_learning.kernels.algorithms`)
 
 .. currentmodule:: qiskit_machine_learning.kernels.algorithms
 
-Quantum Kernels
+Quantum Kernel Algorithms
 ===============
 
 .. autosummary::

--- a/qiskit_machine_learning/kernels/algorithms/__init__.py
+++ b/qiskit_machine_learning/kernels/algorithms/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -16,7 +16,7 @@ Quantum Kernel Algorithms (:mod:`qiskit_machine_learning.kernels.algorithms`)
 .. currentmodule:: qiskit_machine_learning.kernels.algorithms
 
 Quantum Kernel Algorithms
-===============
+=========================
 
 .. autosummary::
    :toctree: ../stubs/


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
closes #303 

A new package was created for last release, `kernels.algorithms`, to hold the QuantumKernelTrainer class. An .rst file was not created for this new package, so the package and its contents do not show up in the web API.


### Details and comments
Added an .rst file so that the kernels.algorithms package (quantum kernel trainer) will populate in web docs.


