### PR TITLE
Add unit tests for QuantumKernel circuit batching

### DIFF
--- a/test/kernels/test_qkernel.py
+++ b/test/kernels/test_qkernel.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/kernels/test_qkernel.py
+++ b/test/kernels/test_qkernel.py
@@ -528,7 +528,7 @@ class TestQuantumKernelBatching(QiskitMachineLearningTestCase):
     Checks batching with both statevector simulator and QASM simulator.
     """
 
-    def __init__(self, methodName='runTest'):
+    def __init__(self, methodName="runTest"):
         super().__init__(methodName)
         self.circuit_counts = []
 

--- a/test/kernels/test_qkernel.py
+++ b/test/kernels/test_qkernel.py
@@ -528,8 +528,8 @@ class TestQuantumKernelBatching(QiskitMachineLearningTestCase):
     Checks batching with both statevector simulator and QASM simulator.
     """
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, methodName='runTest'):
+        super().__init__(methodName)
         self.circuit_counts = []
 
     def count_circuits(self, func):

--- a/test/kernels/test_qkernel.py
+++ b/test/kernels/test_qkernel.py
@@ -519,11 +519,9 @@ class TestQuantumKernelUserParameters(QiskitMachineLearningTestCase):
 class TestQuantumKernelBatching(QiskitMachineLearningTestCase):
     """Test QuantumKernel circuit batching
 
-    Creates a class factory that takes the QuantumInstance class,
-    applies a method decorator to the execute function and returns the modified class.
-    The decorator function records the actual number of circuits being passed
+    Checks that the actual number of circuits being passed
     to execute does not exceed the batch_size requested by the Quantum Kernel.
-    Also checks that the sum of the batch sizes matches the total number of expected
+    Checks that the sum of the batch sizes matches the total number of expected
     circuits.
     Checks batching with both statevector simulator and QASM simulator.
     """

--- a/test/kernels/test_qkernel.py
+++ b/test/kernels/test_qkernel.py
@@ -574,7 +574,8 @@ class TestQuantumKernelBatching(QiskitMachineLearningTestCase):
 
         self.feature_map = ZZFeatureMap(feature_dimension=2, reps=2)
 
-        # Data generated with ad_hoc_data(training_size=4, test_size=2, n=2, gap=0.3)
+        # data generated using
+        # sample_train, label_train, _, _ = ad_hoc_data(training_size=4, test_size=2, n=2, gap=0.3)
         self.sample_train = np.asarray(
             [
                 [5.90619419, 1.25663706],
@@ -588,16 +589,6 @@ class TestQuantumKernelBatching(QiskitMachineLearningTestCase):
             ]
         )
         self.label_train = np.asarray([0, 0, 0, 0, 1, 1, 1, 1])
-
-        self.sample_test = np.asarray(
-            [
-                [0.87964594, 3.76991118],
-                [0.37699112, 1.50796447],
-                [0.12566371, 3.20442451],
-                [4.96371639, 0.0],
-            ]
-        )
-        self.label_test = np.asarray([0, 0, 1, 1])
 
     def test_statevector_batching(self):
         """Test batching when using the statevector simulator"""

--- a/test/kernels/test_qkernel.py
+++ b/test/kernels/test_qkernel.py
@@ -529,7 +529,7 @@ class TestQuantumKernelBatching(QiskitMachineLearningTestCase):
     """
 
     def count_circuits(self, func):
-        """Decorator to record the number of circuits passed to QuantumInstance.execute.
+        """Wrapper to record the number of circuits passed to QuantumInstance.execute.
 
         Args:
             func (Callable): execute function to be wrapped

--- a/test/kernels/test_qkernel.py
+++ b/test/kernels/test_qkernel.py
@@ -519,11 +519,11 @@ class TestQuantumKernelUserParameters(QiskitMachineLearningTestCase):
 class TestQuantumKernelBatching(QiskitMachineLearningTestCase):
     """Test QuantumKernel circuit batching
 
+    Checks batching with both statevector simulator and QASM simulator.
     Checks that the actual number of circuits being passed
     to execute does not exceed the batch_size requested by the Quantum Kernel.
     Checks that the sum of the batch sizes matches the total number of expected
     circuits.
-    Checks batching with both statevector simulator and QASM simulator.
     """
 
     def count_circuits(self, func):
@@ -574,18 +574,30 @@ class TestQuantumKernelBatching(QiskitMachineLearningTestCase):
 
         self.feature_map = ZZFeatureMap(feature_dimension=2, reps=2)
 
+        # Data generated with ad_hoc_data(training_size=4, test_size=2, n=2, gap=0.3)
         self.sample_train = np.asarray(
             [
-                [3.07876080, 1.75929189],
-                [6.03185789, 5.27787566],
-                [6.22035345, 2.70176968],
-                [0.18849556, 2.82743339],
+                [5.90619419, 1.25663706],
+                [2.32477856, 0.9424778],
+                [4.52389342, 5.0893801],
+                [3.58141563, 0.9424778],
+                [0.31415927, 3.45575192],
+                [4.83805269, 3.70707933],
+                [5.65486678, 6.09468975],
+                [5.46637122, 4.52389342],
             ]
         )
-        self.label_train = np.asarray([0, 0, 1, 1])
+        self.label_train = np.asarray([0, 0, 0, 0, 1, 1, 1, 1])
 
-        self.sample_test = np.asarray([[2.199114860, 5.15221195], [0.50265482, 0.06283185]])
-        self.label_test = np.asarray([0, 1])
+        self.sample_test = np.asarray(
+            [
+                [0.87964594, 3.76991118],
+                [0.37699112, 1.50796447],
+                [0.12566371, 3.20442451],
+                [4.96371639, 0.0],
+            ]
+        )
+        self.label_test = np.asarray([0, 0, 1, 1])
 
     def test_statevector_batching(self):
         """Test batching when using the statevector simulator"""
@@ -606,9 +618,6 @@ class TestQuantumKernelBatching(QiskitMachineLearningTestCase):
             self.assertLessEqual(circuit_count, self.batch_size)
 
         self.assertEqual(sum(self.circuit_counts), len(self.sample_train))
-
-        score = svc.score(self.sample_test, self.label_test)
-        self.assertEqual(score, 0.5)
 
     def test_qasm_batching(self):
         """Test batching when using the QASM simulator"""
@@ -631,9 +640,6 @@ class TestQuantumKernelBatching(QiskitMachineLearningTestCase):
         num_circuits = num_train * (num_train - 1) / 2
 
         self.assertEqual(sum(self.circuit_counts), num_circuits)
-
-        score = svc.score(self.sample_test, self.label_test)
-        self.assertEqual(score, 0.5)
 
 
 if __name__ == "__main__":

--- a/test/kernels/test_qkernel.py
+++ b/test/kernels/test_qkernel.py
@@ -560,9 +560,7 @@ class TestQuantumKernelBatching(QiskitMachineLearningTestCase):
         )
 
         # monkey patch the statevector simulator
-        self.statevector_simulator.execute = self.count_circuits(
-            self.statevector_simulator.execute
-        )
+        self.statevector_simulator.execute = self.count_circuits(self.statevector_simulator.execute)
 
         self.qasm_simulator = QuantumInstance(
             BasicAer.get_backend("qasm_simulator"),
@@ -572,9 +570,7 @@ class TestQuantumKernelBatching(QiskitMachineLearningTestCase):
         )
 
         # monkey patch the qasm simulator
-        self.qasm_simulator.execute = self.count_circuits(
-            self.qasm_simulator.execute
-        )
+        self.qasm_simulator.execute = self.count_circuits(self.qasm_simulator.execute)
 
         self.feature_map = ZZFeatureMap(feature_dimension=2, reps=2)
 

--- a/test/kernels/test_qkernel.py
+++ b/test/kernels/test_qkernel.py
@@ -522,7 +522,9 @@ class TestQuantumKernelBatching(QiskitMachineLearningTestCase):
     Creates a class factory that takes the QuantumInstance class,
     applies a method decorator to the execute function and returns the modified class.
     The decorator function records the actual number of circuits being passed
-    to execute does not excede the batch_size requested by the Quantum Kernel.
+    to execute does not exceed the batch_size requested by the Quantum Kernel.
+    Also checks that the sum of the batch sizes matches the total number of expected
+    circuits.
     """
 
     def count_circuits(self, f):

--- a/test/kernels/test_qkernel.py
+++ b/test/kernels/test_qkernel.py
@@ -545,22 +545,6 @@ class TestQuantumKernelBatching(QiskitMachineLearningTestCase):
 
         return wrapper
 
-    def hook_quantum_instance(self):
-        """Hooks into QuantumInstance to monitor circuit batching.
-
-        Class factory that takes the QuantumInstance class, applies a method decorator to the
-        execute function and returns the modified class.
-        """
-
-        class HookedQuantumInstance(QuantumInstance):
-            """Applies the count_circuits decorator to the QuantumInstance.execute function."""
-
-            @self.count_circuits
-            def execute(self, circuits, had_transpiled: bool = False):
-                return super().execute(circuits, had_transpiled)
-
-        return HookedQuantumInstance
-
     def setUp(self):
         super().setUp()
 
@@ -570,14 +554,16 @@ class TestQuantumKernelBatching(QiskitMachineLearningTestCase):
         self.batch_size = 3
         self.circuit_counts = []
 
-        self.statevector_simulator = self.hook_quantum_instance()(
+        QuantumInstance.execute = self.count_circuits(QuantumInstance.execute)
+
+        self.statevector_simulator = QuantumInstance(
             BasicAer.get_backend("statevector_simulator"),
             shots=1,
             seed_simulator=algorithm_globals.random_seed,
             seed_transpiler=algorithm_globals.random_seed,
         )
 
-        self.qasm_simulator = self.hook_quantum_instance()(
+        self.qasm_simulator = QuantumInstance(
             BasicAer.get_backend("qasm_simulator"),
             shots=self.shots,
             seed_simulator=algorithm_globals.random_seed,

--- a/test/kernels/test_qkernel.py
+++ b/test/kernels/test_qkernel.py
@@ -528,10 +528,6 @@ class TestQuantumKernelBatching(QiskitMachineLearningTestCase):
     Checks batching with both statevector simulator and QASM simulator.
     """
 
-    def __init__(self, methodName="runTest"):
-        super().__init__(methodName)
-        self.circuit_counts = []
-
     def count_circuits(self, func):
         """Decorator to record the number of circuits passed to QuantumInstance.execute.
 
@@ -568,11 +564,11 @@ class TestQuantumKernelBatching(QiskitMachineLearningTestCase):
     def setUp(self):
         super().setUp()
 
-        self.batch_size = 3
-
         algorithm_globals.random_seed = 10598
 
         self.shots = 12000
+        self.batch_size = 3
+        self.circuit_counts = []
 
         self.statevector_simulator = self.hook_quantum_instance()(
             BasicAer.get_backend("statevector_simulator"),


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This aims to improve the unit tests for QuantumKernel by testing that batch_size is used correctly for both statevector and QASM simulators. Closes #242.

This follows improvements in the QuantumKernel code related to batching circuits using the statevector simulator (#209).

### Details and comments

It adds a new test class that records the actual number of circuits being passed
to `QuantumInstance.execute` and checks that it does not exceed the `batch_size` requested by `Quantum Kernel`.
It also checks that the sum of the batch sizes matches the total number of expected circuits.
This is tested when using both the statevector and QASM simulators.


