### PR TITLE
297 batch label inference

### DIFF
--- a/qiskit_machine_learning/algorithms/classifiers/vqc.py
+++ b/qiskit_machine_learning/algorithms/classifiers/vqc.py
@@ -9,7 +9,7 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
-"""An implementation of quantum neural network classifier."""
+"""An implementation of variational quantum classifier."""
 
 from typing import Union, Optional, Callable, cast
 import numpy as np
@@ -27,7 +27,17 @@ from .neural_network_classifier import NeuralNetworkClassifier
 
 
 class VQC(NeuralNetworkClassifier):
-    """Quantum neural network classifier."""
+    """Variational quantum classifier.
+
+    The variational quantum classifier is a variational algorithm where the
+    measured expectation value is interpreted as the output of a classifier.
+
+    Only supports one-hot encoded labels;
+    e.g., data like ``[1, 0, 0]``, ``[0, 1, 0]``, ``[0, 0, 1]``.
+
+    Multi-label classification is not supported;
+    e.g., data like ``[1, 1, 0]``, ``[0, 1, 1]``, ``[1, 0, 1]``, ``[1, 1, 1]``.
+    """
 
     def __init__(
         self,
@@ -155,12 +165,12 @@ class VQC(NeuralNetworkClassifier):
 
         Args:
             X: The input data.
-            y: The target values.
+            y: The target values. Required to be one-hot encoded.
 
         Returns:
             self: returns a trained classifier.
         """
-        num_classes = len(np.unique(y, axis=0))
+        num_classes = y.shape[-1]
         cast(CircuitQNN, self._neural_network).set_interpret(
             self._get_interpret(num_classes), num_classes
         )

--- a/qiskit_machine_learning/algorithms/trainable_model.py
+++ b/qiskit_machine_learning/algorithms/trainable_model.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/algorithms/trainable_model.py
+++ b/qiskit_machine_learning/algorithms/trainable_model.py
@@ -201,7 +201,7 @@ class TrainableModel:
             An array as an initial point
         """
         if self._warm_start and self._fit_result is not None:
-            self._initial_point = self._fit_result[0]
+            self._initial_point = self._fit_result.x
         elif self._initial_point is None:
             self._initial_point = algorithm_globals.random.random(self._neural_network.num_weights)
         return self._initial_point

--- a/releasenotes/notes/fix-vqc-warm-start-1c15d3f5742c5e84.yaml
+++ b/releasenotes/notes/fix-vqc-warm-start-1c15d3f5742c5e84.yaml
@@ -1,11 +1,11 @@
 ---
 fixes:
   - |
-    Fixes an issue where `VQC` would fail with `warm_start=True`.
-    The extraction of the `initial_point` in `TrainableModel` from the final
+    Fixes an issue where ``VQC`` would fail with ``warm_start=True``.
+    The extraction of the ``initial_point`` in ``TrainableModel`` from the final
     point of the minimization had not been updated to reflect the refactor
-    of optimizers in `qiskit-terra`; the old `optimize` method, that returned
-    a tuple was deprecated and new method `minimize` was created that returns
-    an `OptimizerResult` object. We now correctly recover the final point of
+    of optimizers in ``qiskit-terra``; the old ``optimize`` method, that returned
+    a tuple was deprecated and new method ``minimize`` was created that returns
+    an ``OptimizerResult`` object. We now correctly recover the final point of
     the minimization from previous fits to use for a warm start in subsequent
     fits.

--- a/releasenotes/notes/fix-vqc-warm-start-1c15d3f5742c5e84.yaml
+++ b/releasenotes/notes/fix-vqc-warm-start-1c15d3f5742c5e84.yaml
@@ -1,0 +1,11 @@
+---
+fixes:
+  - |
+    Fixes an issue where `VQC` would fail with `warm_start=True`.
+    The extraction of the `initial_point` in `TrainableModel` from the final
+    point of the minimization had not been updated to reflect the refactor
+    of optimizers in `qiskit-terra`; the old `optimize` method, that returned
+    a tuple was deprecated and new method `minimize` was created that returns
+    an `OptimizerResult` object. We now correctly recover the final point of
+    the minimization from previous fits to use for a warm start in subsequent
+    fits.

--- a/test/algorithms/classifiers/test_vqc.py
+++ b/test/algorithms/classifiers/test_vqc.py
@@ -287,7 +287,7 @@ class TestVQC(QiskitMachineLearningTestCase):
         classifier.fit(X[num_start:, :], y[num_start:])
         second_fit_initial_point = classifier._initial_point
 
-        # Check the final optimization point from the first fit was used to the start second fit.
+        # Check the final optimization point from the first fit was used to start the second fit.
         np.testing.assert_allclose(first_fit_final_point, second_fit_initial_point)
 
         # Check score.

--- a/test/algorithms/classifiers/test_vqc.py
+++ b/test/algorithms/classifiers/test_vqc.py
@@ -259,7 +259,7 @@ class TestVQC(QiskitMachineLearningTestCase):
         feature_map = ZZFeatureMap(num_inputs)
         ansatz = RealAmplitudes(num_inputs, reps=1)
 
-        # construct data
+        # Construct the data.
         num_samples = 10
         # pylint: disable=invalid-name
         X = algorithm_globals.random.random((num_samples, num_inputs))
@@ -278,16 +278,16 @@ class TestVQC(QiskitMachineLearningTestCase):
             quantum_instance=quantum_instance,
         )
 
-        # Fit the VQC to first half of data.
+        # Fit the VQC to the first half of data.
         num_start = num_samples // 2
         classifier.fit(X[:num_start, :], y[:num_start])
         first_fit_final_point = classifier._fit_result.x
 
-        # Fit the VQC to second half of data with a warm start.
+        # Fit the VQC to the second half of the data with a warm start.
         classifier.fit(X[num_start:, :], y[num_start:])
         second_fit_initial_point = classifier._initial_point
 
-        # Check final optimization point from first fit was used to start second fit.
+        # Check the final optimization point from the first fit was used to the start second fit.
         np.testing.assert_allclose(first_fit_final_point, second_fit_initial_point)
 
         # Check score.

--- a/test/algorithms/classifiers/test_vqc.py
+++ b/test/algorithms/classifiers/test_vqc.py
@@ -230,6 +230,70 @@ class TestVQC(QiskitMachineLearningTestCase):
         score = classifier.score(X, y)
         self.assertGreater(score, 1 / num_classes)
 
+    @data(
+        # optimizer, quantum instance
+        ("cobyla", "statevector"),
+        ("cobyla", "qasm"),
+        ("bfgs", "statevector"),
+        ("bfgs", "qasm"),
+        (None, "statevector"),
+        (None, "qasm"),
+    )
+    def test_warm_start(self, config):
+        """Test VQC with warm_start=True."""
+        opt, q_i = config
+
+        if q_i == "statevector":
+            quantum_instance = self.sv_quantum_instance
+        else:
+            quantum_instance = self.qasm_quantum_instance
+
+        if opt == "bfgs":
+            optimizer = L_BFGS_B(maxiter=5)
+        elif opt == "cobyla":
+            optimizer = COBYLA(maxiter=25)
+        else:
+            optimizer = None
+
+        num_inputs = 2
+        feature_map = ZZFeatureMap(num_inputs)
+        ansatz = RealAmplitudes(num_inputs, reps=1)
+
+        # construct data
+        num_samples = 10
+        # pylint: disable=invalid-name
+        X = algorithm_globals.random.random((num_samples, num_inputs))
+        y = 1.0 * (np.sum(X, axis=1) <= 1)
+        while len(np.unique(y)) == 1:
+            X = algorithm_globals.random.random((num_samples, num_inputs))
+            y = 1.0 * (np.sum(X, axis=1) <= 1)
+        y = np.array([y, 1 - y]).transpose()  # VQC requires one-hot encoded input.
+
+        # Initialise the VQC.
+        classifier = VQC(
+            feature_map=feature_map,
+            ansatz=ansatz,
+            optimizer=optimizer,
+            warm_start=True,
+            quantum_instance=quantum_instance,
+        )
+
+        # Fit the VQC to first half of data.
+        num_start = num_samples // 2
+        classifier.fit(X[:num_start, :], y[:num_start])
+        first_fit_final_point = classifier._fit_result.x
+
+        # Fit the VQC to second half of data with a warm start.
+        classifier.fit(X[num_start:, :], y[num_start:])
+        second_fit_initial_point = classifier._initial_point
+
+        # Check final optimization point from first fit was used to start second fit.
+        np.testing.assert_allclose(first_fit_final_point, second_fit_initial_point)
+
+        # Check score.
+        score = classifier.score(X, y)
+        self.assertGreater(score, 0.5)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/algorithms/classifiers/test_vqc.py
+++ b/test/algorithms/classifiers/test_vqc.py
@@ -278,7 +278,7 @@ class TestVQC(QiskitMachineLearningTestCase):
             quantum_instance=quantum_instance,
         )
 
-        # Fit the VQC to the first half of data.
+        # Fit the VQC to the first half of the data.
         num_start = num_samples // 2
         classifier.fit(X[:num_start, :], y[:num_start])
         first_fit_final_point = classifier._fit_result.x

--- a/test/algorithms/classifiers/test_vqc.py
+++ b/test/algorithms/classifiers/test_vqc.py
@@ -269,7 +269,7 @@ class TestVQC(QiskitMachineLearningTestCase):
             y = 1.0 * (np.sum(X, axis=1) <= 1)
         y = np.array([y, 1 - y]).transpose()  # VQC requires one-hot encoded input.
 
-        # Initialise the VQC.
+        # Initialize the VQC.
         classifier = VQC(
             feature_map=feature_map,
             ansatz=ansatz,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #297. Currently, VQC will throw an error if trained on batches of data where not all of the target labels that can be found in the full dataset are present. This is because VQC interprets the number of unique labels in the current batch as the number of classes. 

Currently, VQC is hard-coded to expect one-hot encoded labels. Therefore, I suggest a small change to determine the number of classes from the shape of the label array. I have also edited the docstring to add the label encoding requirements of the current VQC implementation.

### Details and comments

Related issues that I will raise separately:
- I may also add a warning when running with a warm start and fitting to data with a different number of one-hot labels, as I would expect this to invalidate any previous fit.
- While multi-label classification is not supported, the code will not raise an error when it is provided.
- In future, it might be good for VQC to accept different label encodings, in line with what an sklearn user might expect.


