### PR TITLE
fixes #297: fitting in batches without all labels

### DIFF
--- a/qiskit_machine_learning/algorithms/classifiers/vqc.py
+++ b/qiskit_machine_learning/algorithms/classifiers/vqc.py
@@ -9,7 +9,7 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
-"""An implementation of quantum neural network classifier."""
+"""An implementation of variational quantum classifier."""
 
 from typing import Union, Optional, Callable, cast
 import numpy as np
@@ -27,7 +27,17 @@ from .neural_network_classifier import NeuralNetworkClassifier
 
 
 class VQC(NeuralNetworkClassifier):
-    """Quantum neural network classifier."""
+    """Variational quantum classifier.
+
+    The variational quantum classifier is a variational algorithm where the
+    measured expectation value is interpreted as the output of a classifier.
+
+    Only supports one-hot encoded labels;
+    e.g., data like ``[1, 0, 0]``, ``[0, 1, 0]``, ``[0, 0, 1]``.
+
+    Multi-label classification is not supported;
+    e.g., data like ``[1, 1, 0]``, ``[0, 1, 1]``, ``[1, 0, 1]``, ``[1, 1, 1]``.
+    """
 
     def __init__(
         self,
@@ -155,12 +165,12 @@ class VQC(NeuralNetworkClassifier):
 
         Args:
             X: The input data.
-            y: The target values.
+            y: The target values. Required to be one-hot encoded.
 
         Returns:
             self: returns a trained classifier.
         """
-        num_classes = len(np.unique(y, axis=0))
+        num_classes = y.shape[-1]
         cast(CircuitQNN, self._neural_network).set_interpret(
             self._get_interpret(num_classes), num_classes
         )

--- a/releasenotes/notes/fix-batching-with-incomplete-labels-2fcf26585903d437.yaml
+++ b/releasenotes/notes/fix-batching-with-incomplete-labels-2fcf26585903d437.yaml
@@ -6,5 +6,4 @@ fixes:
     present. This is because VQC interpreted the number of unique targets in
     the current batch as the number of classes. Currently, VQC is hard-coded
     to expect one-hot-encoded targets. Therefore, VQC will now determine the
-    number of classes from the shape of the target array. The docstring now
-    reaffirms the requirement for one-hot-encoded data.
+    number of classes from the shape of the target array.

--- a/releasenotes/notes/fix-batching-with-incomplete-labels-2fcf26585903d437.yaml
+++ b/releasenotes/notes/fix-batching-with-incomplete-labels-2fcf26585903d437.yaml
@@ -7,4 +7,4 @@ fixes:
     the current batch as the number of classes. Currently, VQC is hard-coded
     to expect one-hot-encoded targets. Therefore, VQC will now determine the
     number of classes from the shape of the target array. The docstring now
-    reaffirms the requirement for one-hot-encoded-data.
+    reaffirms the requirement for one-hot-encoded data.

--- a/releasenotes/notes/fix-batching-with-incomplete-labels-2fcf26585903d437.yaml
+++ b/releasenotes/notes/fix-batching-with-incomplete-labels-2fcf26585903d437.yaml
@@ -1,0 +1,10 @@
+---
+fixes:
+  - |
+    Previously, VQC would throw an error if trained on batches of data where
+    not all of the target labels that can be found in the full dataset were
+    present. This is because VQC interpreted the number of unique targets in
+    the current batch as the number of classes. Currently, VQC is hard-coded
+    to expect one-hot-encoded targets. Therefore, VQC will now determine the
+    number of classes from the shape of the target array. The docstring now
+    reaffirms the requirement for one-hot-encoded-data.

--- a/test/algorithms/classifiers/test_vqc.py
+++ b/test/algorithms/classifiers/test_vqc.py
@@ -47,6 +47,253 @@ class TestVQC(QiskitMachineLearningTestCase):
             seed_transpiler=algorithm_globals.random_seed,
         )
 
+    # @data(
+    #     # optimizer, quantum instance
+    #     ("cobyla", "statevector"),
+    #     ("cobyla", "qasm"),
+    #     ("bfgs", "statevector"),
+    #     ("bfgs", "qasm"),
+    #     (None, "statevector"),
+    #     (None, "qasm"),
+    # )
+    # def test_vqc(self, config):
+    #     """Test VQC."""
+
+    #     opt, q_i = config
+
+    #     if q_i == "statevector":
+    #         quantum_instance = self.sv_quantum_instance
+    #     else:
+    #         quantum_instance = self.qasm_quantum_instance
+
+    #     if opt == "bfgs":
+    #         optimizer = L_BFGS_B(maxiter=5)
+    #     elif opt == "cobyla":
+    #         optimizer = COBYLA(maxiter=25)
+    #     else:
+    #         optimizer = None
+
+    #     num_inputs = 2
+    #     feature_map = ZZFeatureMap(num_inputs)
+    #     ansatz = RealAmplitudes(num_inputs, reps=1)
+    #     # fix the initial point
+    #     initial_point = np.array([0.5] * ansatz.num_parameters)
+
+    #     # construct classifier - note: CrossEntropy requires eval_probabilities=True!
+    #     classifier = VQC(
+    #         feature_map=feature_map,
+    #         ansatz=ansatz,
+    #         optimizer=optimizer,
+    #         quantum_instance=quantum_instance,
+    #         initial_point=initial_point,
+    #     )
+
+    #     # construct data
+    #     num_samples = 5
+    #     # pylint: disable=invalid-name
+    #     X = algorithm_globals.random.random((num_samples, num_inputs))
+    #     y = 1.0 * (np.sum(X, axis=1) <= 1)
+    #     while len(np.unique(y)) == 1:
+    #         X = algorithm_globals.random.random((num_samples, num_inputs))
+    #         y = 1.0 * (np.sum(X, axis=1) <= 1)
+    #     y = np.array([y, 1 - y]).transpose()  # VQC requires one-hot encoded input
+
+    #     # fit to data
+    #     classifier.fit(X, y)
+
+    #     # score
+    #     score = classifier.score(X, y)
+    #     self.assertGreater(score, 0.5)
+
+    # @data(
+    #     # num_qubits, feature_map, ansatz
+    #     (True, False, False),
+    #     (True, True, False),
+    #     (True, True, True),
+    #     (False, True, True),
+    #     (False, False, True),
+    #     (True, False, True),
+    #     (False, True, False),
+    # )
+    # def test_default_parameters(self, config):
+    #     """Test VQC instantiation with default parameters."""
+
+    #     provide_num_qubits, provide_feature_map, provide_ansatz = config
+    #     num_inputs = 2
+
+    #     num_qubits, feature_map, ansatz = None, None, None
+
+    #     if provide_num_qubits:
+    #         num_qubits = num_inputs
+    #     if provide_feature_map:
+    #         feature_map = ZZFeatureMap(num_inputs)
+    #     if provide_ansatz:
+    #         ansatz = RealAmplitudes(num_inputs, reps=1)
+
+    #     classifier = VQC(
+    #         num_qubits=num_qubits,
+    #         feature_map=feature_map,
+    #         ansatz=ansatz,
+    #         quantum_instance=self.qasm_quantum_instance,
+    #     )
+
+    #     # construct data
+    #     num_samples = 5
+    #     # pylint: disable=invalid-name
+    #     X = algorithm_globals.random.random((num_samples, num_inputs))
+    #     y = 1.0 * (np.sum(X, axis=1) <= 1)
+    #     while len(np.unique(y)) == 1:
+    #         X = algorithm_globals.random.random((num_samples, num_inputs))
+    #         y = 1.0 * (np.sum(X, axis=1) <= 1)
+    #     y = np.array([y, 1 - y]).transpose()  # VQC requires one-hot encoded input
+
+    #     # fit to data
+    #     classifier.fit(X, y)
+
+    #     # score
+    #     score = classifier.score(X, y)
+    #     self.assertGreater(score, 0.5)
+
+    # @data(
+    #     # optimizer, quantum instance
+    #     ("cobyla", "statevector"),
+    #     ("cobyla", "qasm"),
+    #     ("bfgs", "statevector"),
+    #     ("bfgs", "qasm"),
+    #     (None, "statevector"),
+    #     (None, "qasm"),
+    # )
+    # def test_multiclass(self, config):
+    #     """Test multiclass VQC."""
+    #     opt, q_i = config
+
+    #     if q_i == "statevector":
+    #         quantum_instance = self.sv_quantum_instance
+    #     else:
+    #         quantum_instance = self.qasm_quantum_instance
+
+    #     if opt == "bfgs":
+    #         optimizer = L_BFGS_B(maxiter=5)
+    #     elif opt == "cobyla":
+    #         optimizer = COBYLA(maxiter=25)
+    #     else:
+    #         optimizer = None
+
+    #     num_inputs = 2
+    #     feature_map = ZZFeatureMap(num_inputs)
+    #     ansatz = RealAmplitudes(num_inputs, reps=1)
+    #     # fix the initial point
+    #     initial_point = np.array([0.5] * ansatz.num_parameters)
+
+    #     # construct classifier - note: CrossEntropy requires eval_probabilities=True!
+    #     classifier = VQC(
+    #         feature_map=feature_map,
+    #         ansatz=ansatz,
+    #         optimizer=optimizer,
+    #         quantum_instance=quantum_instance,
+    #         initial_point=initial_point,
+    #     )
+
+    #     # construct data
+    #     num_samples = 5
+    #     num_classes = 5
+    #     # pylint: disable=invalid-name
+
+    #     # We create a dataset that is random, but has some training signal, as follows:
+    #     # First, we create a random feature matrix X, but sort it by the row-wise sum in ascending
+    #     # order.
+    #     X = algorithm_globals.random.random((num_samples, num_inputs))
+    #     X = X[X.sum(1).argsort()]
+
+    #     # Next we create an array which contains all class labels, multiple times if num_samples <
+    #     # num_classes, and in ascending order (e.g. [0, 0, 1, 1, 2]). So now we have a dataset
+    #     # where the row-sum of X is correlated with the class label (i.e. smaller row-sum is more
+    #     # likely to belong to class 0, and big row-sum is more likely to belong to class >0)
+    #     y_indices = (
+    #         np.digitize(np.arange(0, 1, 1 / num_samples), np.arange(0, 1, 1 / num_classes)) - 1
+    #     )
+
+    #     # Third, we random shuffle both X and y_indices
+    #     permutation = np.random.permutation(np.arange(num_samples))
+    #     X = X[permutation]
+    #     y_indices = y_indices[permutation]
+
+    #     # Lastly we create a 1-hot label matrix y
+    #     y = np.zeros((num_samples, num_classes))
+    #     for e, index in enumerate(y_indices):
+    #         y[e, index] = 1
+
+    #     # fit to data
+    #     classifier.fit(X, y)
+
+    #     # score
+    #     score = classifier.score(X, y)
+    #     self.assertGreater(score, 1 / num_classes)
+
+    # @data(
+    #     # optimizer, quantum instance
+    #     ("cobyla", "statevector"),
+    #     ("cobyla", "qasm"),
+    #     ("bfgs", "statevector"),
+    #     ("bfgs", "qasm"),
+    #     (None, "statevector"),
+    #     (None, "qasm"),
+    # )
+    # def test_warm_start(self, config):
+    #     """Test VQC with warm_start=True."""
+    #     opt, q_i = config
+
+    #     if q_i == "statevector":
+    #         quantum_instance = self.sv_quantum_instance
+    #     else:
+    #         quantum_instance = self.qasm_quantum_instance
+
+    #     if opt == "bfgs":
+    #         optimizer = L_BFGS_B(maxiter=5)
+    #     elif opt == "cobyla":
+    #         optimizer = COBYLA(maxiter=25)
+    #     else:
+    #         optimizer = None
+
+    #     num_inputs = 2
+    #     feature_map = ZZFeatureMap(num_inputs)
+    #     ansatz = RealAmplitudes(num_inputs, reps=1)
+
+    #     # Construct the data.
+    #     num_samples = 10
+    #     # pylint: disable=invalid-name
+    #     X = algorithm_globals.random.random((num_samples, num_inputs))
+    #     y = 1.0 * (np.sum(X, axis=1) <= 1)
+    #     while len(np.unique(y)) == 1:
+    #         X = algorithm_globals.random.random((num_samples, num_inputs))
+    #         y = 1.0 * (np.sum(X, axis=1) <= 1)
+    #     y = np.array([y, 1 - y]).transpose()  # VQC requires one-hot encoded input.
+
+    #     # Initialize the VQC.
+    #     classifier = VQC(
+    #         feature_map=feature_map,
+    #         ansatz=ansatz,
+    #         optimizer=optimizer,
+    #         warm_start=True,
+    #         quantum_instance=quantum_instance,
+    #     )
+
+    #     # Fit the VQC to the first half of the data.
+    #     num_start = num_samples // 2
+    #     classifier.fit(X[:num_start, :], y[:num_start])
+    #     first_fit_final_point = classifier._fit_result.x
+
+    #     # Fit the VQC to the second half of the data with a warm start.
+    #     classifier.fit(X[num_start:, :], y[num_start:])
+    #     second_fit_initial_point = classifier._initial_point
+
+    #     # Check the final optimization point from the first fit was used to start the second fit.
+    #     np.testing.assert_allclose(first_fit_final_point, second_fit_initial_point)
+
+    #     # Check score.
+    #     score = classifier.score(X, y)
+    #     self.assertGreater(score, 0.5)
+
     @data(
         # optimizer, quantum instance
         ("cobyla", "statevector"),
@@ -56,191 +303,8 @@ class TestVQC(QiskitMachineLearningTestCase):
         (None, "statevector"),
         (None, "qasm"),
     )
-    def test_vqc(self, config):
-        """Test VQC."""
-
-        opt, q_i = config
-
-        if q_i == "statevector":
-            quantum_instance = self.sv_quantum_instance
-        else:
-            quantum_instance = self.qasm_quantum_instance
-
-        if opt == "bfgs":
-            optimizer = L_BFGS_B(maxiter=5)
-        elif opt == "cobyla":
-            optimizer = COBYLA(maxiter=25)
-        else:
-            optimizer = None
-
-        num_inputs = 2
-        feature_map = ZZFeatureMap(num_inputs)
-        ansatz = RealAmplitudes(num_inputs, reps=1)
-        # fix the initial point
-        initial_point = np.array([0.5] * ansatz.num_parameters)
-
-        # construct classifier - note: CrossEntropy requires eval_probabilities=True!
-        classifier = VQC(
-            feature_map=feature_map,
-            ansatz=ansatz,
-            optimizer=optimizer,
-            quantum_instance=quantum_instance,
-            initial_point=initial_point,
-        )
-
-        # construct data
-        num_samples = 5
-        # pylint: disable=invalid-name
-        X = algorithm_globals.random.random((num_samples, num_inputs))
-        y = 1.0 * (np.sum(X, axis=1) <= 1)
-        while len(np.unique(y)) == 1:
-            X = algorithm_globals.random.random((num_samples, num_inputs))
-            y = 1.0 * (np.sum(X, axis=1) <= 1)
-        y = np.array([y, 1 - y]).transpose()  # VQC requires one-hot encoded input
-
-        # fit to data
-        classifier.fit(X, y)
-
-        # score
-        score = classifier.score(X, y)
-        self.assertGreater(score, 0.5)
-
-    @data(
-        # num_qubits, feature_map, ansatz
-        (True, False, False),
-        (True, True, False),
-        (True, True, True),
-        (False, True, True),
-        (False, False, True),
-        (True, False, True),
-        (False, True, False),
-    )
-    def test_default_parameters(self, config):
-        """Test VQC instantiation with default parameters."""
-
-        provide_num_qubits, provide_feature_map, provide_ansatz = config
-        num_inputs = 2
-
-        num_qubits, feature_map, ansatz = None, None, None
-
-        if provide_num_qubits:
-            num_qubits = num_inputs
-        if provide_feature_map:
-            feature_map = ZZFeatureMap(num_inputs)
-        if provide_ansatz:
-            ansatz = RealAmplitudes(num_inputs, reps=1)
-
-        classifier = VQC(
-            num_qubits=num_qubits,
-            feature_map=feature_map,
-            ansatz=ansatz,
-            quantum_instance=self.qasm_quantum_instance,
-        )
-
-        # construct data
-        num_samples = 5
-        # pylint: disable=invalid-name
-        X = algorithm_globals.random.random((num_samples, num_inputs))
-        y = 1.0 * (np.sum(X, axis=1) <= 1)
-        while len(np.unique(y)) == 1:
-            X = algorithm_globals.random.random((num_samples, num_inputs))
-            y = 1.0 * (np.sum(X, axis=1) <= 1)
-        y = np.array([y, 1 - y]).transpose()  # VQC requires one-hot encoded input
-
-        # fit to data
-        classifier.fit(X, y)
-
-        # score
-        score = classifier.score(X, y)
-        self.assertGreater(score, 0.5)
-
-    @data(
-        # optimizer, quantum instance
-        ("cobyla", "statevector"),
-        ("cobyla", "qasm"),
-        ("bfgs", "statevector"),
-        ("bfgs", "qasm"),
-        (None, "statevector"),
-        (None, "qasm"),
-    )
-    def test_multiclass(self, config):
-        """Test multiclass VQC."""
-        opt, q_i = config
-
-        if q_i == "statevector":
-            quantum_instance = self.sv_quantum_instance
-        else:
-            quantum_instance = self.qasm_quantum_instance
-
-        if opt == "bfgs":
-            optimizer = L_BFGS_B(maxiter=5)
-        elif opt == "cobyla":
-            optimizer = COBYLA(maxiter=25)
-        else:
-            optimizer = None
-
-        num_inputs = 2
-        feature_map = ZZFeatureMap(num_inputs)
-        ansatz = RealAmplitudes(num_inputs, reps=1)
-        # fix the initial point
-        initial_point = np.array([0.5] * ansatz.num_parameters)
-
-        # construct classifier - note: CrossEntropy requires eval_probabilities=True!
-        classifier = VQC(
-            feature_map=feature_map,
-            ansatz=ansatz,
-            optimizer=optimizer,
-            quantum_instance=quantum_instance,
-            initial_point=initial_point,
-        )
-
-        # construct data
-        num_samples = 5
-        num_classes = 5
-        # pylint: disable=invalid-name
-
-        # We create a dataset that is random, but has some training signal, as follows:
-        # First, we create a random feature matrix X, but sort it by the row-wise sum in ascending
-        # order.
-        X = algorithm_globals.random.random((num_samples, num_inputs))
-        X = X[X.sum(1).argsort()]
-
-        # Next we create an array which contains all class labels, multiple times if num_samples <
-        # num_classes, and in ascending order (e.g. [0, 0, 1, 1, 2]). So now we have a dataset
-        # where the row-sum of X is correlated with the class label (i.e. smaller row-sum is more
-        # likely to belong to class 0, and big row-sum is more likely to belong to class >0)
-        y_indices = (
-            np.digitize(np.arange(0, 1, 1 / num_samples), np.arange(0, 1, 1 / num_classes)) - 1
-        )
-
-        # Third, we random shuffle both X and y_indices
-        permutation = np.random.permutation(np.arange(num_samples))
-        X = X[permutation]
-        y_indices = y_indices[permutation]
-
-        # Lastly we create a 1-hot label matrix y
-        y = np.zeros((num_samples, num_classes))
-        for e, index in enumerate(y_indices):
-            y[e, index] = 1
-
-        # fit to data
-        classifier.fit(X, y)
-
-        # score
-        score = classifier.score(X, y)
-        self.assertGreater(score, 1 / num_classes)
-
-    @data(
-        # optimizer, quantum instance
-        ("cobyla", "statevector"),
-        ("cobyla", "qasm"),
-        ("bfgs", "statevector"),
-        ("bfgs", "qasm"),
-        (None, "statevector"),
-        (None, "qasm"),
-    )
-    def test_warm_start(self, config):
-        """Test VQC with warm_start=True."""
+    def test_batches_with_incomplete_labels(self, config):
+        """Test VQC when some batches do not include all possible labels."""
         opt, q_i = config
 
         if q_i == "statevector":
@@ -260,14 +324,12 @@ class TestVQC(QiskitMachineLearningTestCase):
         ansatz = RealAmplitudes(num_inputs, reps=1)
 
         # Construct the data.
-        num_samples = 10
-        # pylint: disable=invalid-name
-        X = algorithm_globals.random.random((num_samples, num_inputs))
-        y = 1.0 * (np.sum(X, axis=1) <= 1)
-        while len(np.unique(y)) == 1:
-            X = algorithm_globals.random.random((num_samples, num_inputs))
-            y = 1.0 * (np.sum(X, axis=1) <= 1)
-        y = np.array([y, 1 - y]).transpose()  # VQC requires one-hot encoded input.
+        features = algorithm_globals.random.random((15, num_inputs))
+        target = np.asarray([0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2])
+
+        # One-hot encode the target.
+        target_onehot = np.zeros((target.size, int(target.max() + 1)))
+        target_onehot[np.arange(target.size), target.astype(int)] = 1
 
         # Initialize the VQC.
         classifier = VQC(
@@ -278,21 +340,14 @@ class TestVQC(QiskitMachineLearningTestCase):
             quantum_instance=quantum_instance,
         )
 
-        # Fit the VQC to the first half of the data.
-        num_start = num_samples // 2
-        classifier.fit(X[:num_start, :], y[:num_start])
-        first_fit_final_point = classifier._fit_result.x
+        # Fit the VQC to the first third of the data.
+        classifier.fit(features[:5, :], target_onehot[:5])
 
-        # Fit the VQC to the second half of the data with a warm start.
-        classifier.fit(X[num_start:, :], y[num_start:])
-        second_fit_initial_point = classifier._initial_point
+        # Fit the VQC to the second third of the data with a warm start.
+        classifier.fit(features[5:10, :], target_onehot[5:10])
 
-        # Check the final optimization point from the first fit was used to start the second fit.
-        np.testing.assert_allclose(first_fit_final_point, second_fit_initial_point)
-
-        # Check score.
-        score = classifier.score(X, y)
-        self.assertGreater(score, 0.5)
+        # Fit the VQC to the third third of the data with a warm start.
+        classifier.fit(features[10:, :], target_onehot[10:])
 
 
 if __name__ == "__main__":

--- a/test/algorithms/classifiers/test_vqc.py
+++ b/test/algorithms/classifiers/test_vqc.py
@@ -47,252 +47,252 @@ class TestVQC(QiskitMachineLearningTestCase):
             seed_transpiler=algorithm_globals.random_seed,
         )
 
-    # @data(
-    #     # optimizer, quantum instance
-    #     ("cobyla", "statevector"),
-    #     ("cobyla", "qasm"),
-    #     ("bfgs", "statevector"),
-    #     ("bfgs", "qasm"),
-    #     (None, "statevector"),
-    #     (None, "qasm"),
-    # )
-    # def test_vqc(self, config):
-    #     """Test VQC."""
+    @data(
+        # optimizer, quantum instance
+        ("cobyla", "statevector"),
+        ("cobyla", "qasm"),
+        ("bfgs", "statevector"),
+        ("bfgs", "qasm"),
+        (None, "statevector"),
+        (None, "qasm"),
+    )
+    def test_vqc(self, config):
+        """Test VQC."""
 
-    #     opt, q_i = config
+        opt, q_i = config
 
-    #     if q_i == "statevector":
-    #         quantum_instance = self.sv_quantum_instance
-    #     else:
-    #         quantum_instance = self.qasm_quantum_instance
+        if q_i == "statevector":
+            quantum_instance = self.sv_quantum_instance
+        else:
+            quantum_instance = self.qasm_quantum_instance
 
-    #     if opt == "bfgs":
-    #         optimizer = L_BFGS_B(maxiter=5)
-    #     elif opt == "cobyla":
-    #         optimizer = COBYLA(maxiter=25)
-    #     else:
-    #         optimizer = None
+        if opt == "bfgs":
+            optimizer = L_BFGS_B(maxiter=5)
+        elif opt == "cobyla":
+            optimizer = COBYLA(maxiter=25)
+        else:
+            optimizer = None
 
-    #     num_inputs = 2
-    #     feature_map = ZZFeatureMap(num_inputs)
-    #     ansatz = RealAmplitudes(num_inputs, reps=1)
-    #     # fix the initial point
-    #     initial_point = np.array([0.5] * ansatz.num_parameters)
+        num_inputs = 2
+        feature_map = ZZFeatureMap(num_inputs)
+        ansatz = RealAmplitudes(num_inputs, reps=1)
+        # fix the initial point
+        initial_point = np.array([0.5] * ansatz.num_parameters)
 
-    #     # construct classifier - note: CrossEntropy requires eval_probabilities=True!
-    #     classifier = VQC(
-    #         feature_map=feature_map,
-    #         ansatz=ansatz,
-    #         optimizer=optimizer,
-    #         quantum_instance=quantum_instance,
-    #         initial_point=initial_point,
-    #     )
+        # construct classifier - note: CrossEntropy requires eval_probabilities=True!
+        classifier = VQC(
+            feature_map=feature_map,
+            ansatz=ansatz,
+            optimizer=optimizer,
+            quantum_instance=quantum_instance,
+            initial_point=initial_point,
+        )
 
-    #     # construct data
-    #     num_samples = 5
-    #     # pylint: disable=invalid-name
-    #     X = algorithm_globals.random.random((num_samples, num_inputs))
-    #     y = 1.0 * (np.sum(X, axis=1) <= 1)
-    #     while len(np.unique(y)) == 1:
-    #         X = algorithm_globals.random.random((num_samples, num_inputs))
-    #         y = 1.0 * (np.sum(X, axis=1) <= 1)
-    #     y = np.array([y, 1 - y]).transpose()  # VQC requires one-hot encoded input
+        # construct data
+        num_samples = 5
+        # pylint: disable=invalid-name
+        X = algorithm_globals.random.random((num_samples, num_inputs))
+        y = 1.0 * (np.sum(X, axis=1) <= 1)
+        while len(np.unique(y)) == 1:
+            X = algorithm_globals.random.random((num_samples, num_inputs))
+            y = 1.0 * (np.sum(X, axis=1) <= 1)
+        y = np.array([y, 1 - y]).transpose()  # VQC requires one-hot encoded input
 
-    #     # fit to data
-    #     classifier.fit(X, y)
+        # fit to data
+        classifier.fit(X, y)
 
-    #     # score
-    #     score = classifier.score(X, y)
-    #     self.assertGreater(score, 0.5)
+        # score
+        score = classifier.score(X, y)
+        self.assertGreater(score, 0.5)
 
-    # @data(
-    #     # num_qubits, feature_map, ansatz
-    #     (True, False, False),
-    #     (True, True, False),
-    #     (True, True, True),
-    #     (False, True, True),
-    #     (False, False, True),
-    #     (True, False, True),
-    #     (False, True, False),
-    # )
-    # def test_default_parameters(self, config):
-    #     """Test VQC instantiation with default parameters."""
+    @data(
+        # num_qubits, feature_map, ansatz
+        (True, False, False),
+        (True, True, False),
+        (True, True, True),
+        (False, True, True),
+        (False, False, True),
+        (True, False, True),
+        (False, True, False),
+    )
+    def test_default_parameters(self, config):
+        """Test VQC instantiation with default parameters."""
 
-    #     provide_num_qubits, provide_feature_map, provide_ansatz = config
-    #     num_inputs = 2
+        provide_num_qubits, provide_feature_map, provide_ansatz = config
+        num_inputs = 2
 
-    #     num_qubits, feature_map, ansatz = None, None, None
+        num_qubits, feature_map, ansatz = None, None, None
 
-    #     if provide_num_qubits:
-    #         num_qubits = num_inputs
-    #     if provide_feature_map:
-    #         feature_map = ZZFeatureMap(num_inputs)
-    #     if provide_ansatz:
-    #         ansatz = RealAmplitudes(num_inputs, reps=1)
+        if provide_num_qubits:
+            num_qubits = num_inputs
+        if provide_feature_map:
+            feature_map = ZZFeatureMap(num_inputs)
+        if provide_ansatz:
+            ansatz = RealAmplitudes(num_inputs, reps=1)
 
-    #     classifier = VQC(
-    #         num_qubits=num_qubits,
-    #         feature_map=feature_map,
-    #         ansatz=ansatz,
-    #         quantum_instance=self.qasm_quantum_instance,
-    #     )
+        classifier = VQC(
+            num_qubits=num_qubits,
+            feature_map=feature_map,
+            ansatz=ansatz,
+            quantum_instance=self.qasm_quantum_instance,
+        )
 
-    #     # construct data
-    #     num_samples = 5
-    #     # pylint: disable=invalid-name
-    #     X = algorithm_globals.random.random((num_samples, num_inputs))
-    #     y = 1.0 * (np.sum(X, axis=1) <= 1)
-    #     while len(np.unique(y)) == 1:
-    #         X = algorithm_globals.random.random((num_samples, num_inputs))
-    #         y = 1.0 * (np.sum(X, axis=1) <= 1)
-    #     y = np.array([y, 1 - y]).transpose()  # VQC requires one-hot encoded input
+        # construct data
+        num_samples = 5
+        # pylint: disable=invalid-name
+        X = algorithm_globals.random.random((num_samples, num_inputs))
+        y = 1.0 * (np.sum(X, axis=1) <= 1)
+        while len(np.unique(y)) == 1:
+            X = algorithm_globals.random.random((num_samples, num_inputs))
+            y = 1.0 * (np.sum(X, axis=1) <= 1)
+        y = np.array([y, 1 - y]).transpose()  # VQC requires one-hot encoded input
 
-    #     # fit to data
-    #     classifier.fit(X, y)
+        # fit to data
+        classifier.fit(X, y)
 
-    #     # score
-    #     score = classifier.score(X, y)
-    #     self.assertGreater(score, 0.5)
+        # score
+        score = classifier.score(X, y)
+        self.assertGreater(score, 0.5)
 
-    # @data(
-    #     # optimizer, quantum instance
-    #     ("cobyla", "statevector"),
-    #     ("cobyla", "qasm"),
-    #     ("bfgs", "statevector"),
-    #     ("bfgs", "qasm"),
-    #     (None, "statevector"),
-    #     (None, "qasm"),
-    # )
-    # def test_multiclass(self, config):
-    #     """Test multiclass VQC."""
-    #     opt, q_i = config
+    @data(
+        # optimizer, quantum instance
+        ("cobyla", "statevector"),
+        ("cobyla", "qasm"),
+        ("bfgs", "statevector"),
+        ("bfgs", "qasm"),
+        (None, "statevector"),
+        (None, "qasm"),
+    )
+    def test_multiclass(self, config):
+        """Test multiclass VQC."""
+        opt, q_i = config
 
-    #     if q_i == "statevector":
-    #         quantum_instance = self.sv_quantum_instance
-    #     else:
-    #         quantum_instance = self.qasm_quantum_instance
+        if q_i == "statevector":
+            quantum_instance = self.sv_quantum_instance
+        else:
+            quantum_instance = self.qasm_quantum_instance
 
-    #     if opt == "bfgs":
-    #         optimizer = L_BFGS_B(maxiter=5)
-    #     elif opt == "cobyla":
-    #         optimizer = COBYLA(maxiter=25)
-    #     else:
-    #         optimizer = None
+        if opt == "bfgs":
+            optimizer = L_BFGS_B(maxiter=5)
+        elif opt == "cobyla":
+            optimizer = COBYLA(maxiter=25)
+        else:
+            optimizer = None
 
-    #     num_inputs = 2
-    #     feature_map = ZZFeatureMap(num_inputs)
-    #     ansatz = RealAmplitudes(num_inputs, reps=1)
-    #     # fix the initial point
-    #     initial_point = np.array([0.5] * ansatz.num_parameters)
+        num_inputs = 2
+        feature_map = ZZFeatureMap(num_inputs)
+        ansatz = RealAmplitudes(num_inputs, reps=1)
+        # fix the initial point
+        initial_point = np.array([0.5] * ansatz.num_parameters)
 
-    #     # construct classifier - note: CrossEntropy requires eval_probabilities=True!
-    #     classifier = VQC(
-    #         feature_map=feature_map,
-    #         ansatz=ansatz,
-    #         optimizer=optimizer,
-    #         quantum_instance=quantum_instance,
-    #         initial_point=initial_point,
-    #     )
+        # construct classifier - note: CrossEntropy requires eval_probabilities=True!
+        classifier = VQC(
+            feature_map=feature_map,
+            ansatz=ansatz,
+            optimizer=optimizer,
+            quantum_instance=quantum_instance,
+            initial_point=initial_point,
+        )
 
-    #     # construct data
-    #     num_samples = 5
-    #     num_classes = 5
-    #     # pylint: disable=invalid-name
+        # construct data
+        num_samples = 5
+        num_classes = 5
+        # pylint: disable=invalid-name
 
-    #     # We create a dataset that is random, but has some training signal, as follows:
-    #     # First, we create a random feature matrix X, but sort it by the row-wise sum in ascending
-    #     # order.
-    #     X = algorithm_globals.random.random((num_samples, num_inputs))
-    #     X = X[X.sum(1).argsort()]
+        # We create a dataset that is random, but has some training signal, as follows:
+        # First, we create a random feature matrix X, but sort it by the row-wise sum in ascending
+        # order.
+        X = algorithm_globals.random.random((num_samples, num_inputs))
+        X = X[X.sum(1).argsort()]
 
-    #     # Next we create an array which contains all class labels, multiple times if num_samples <
-    #     # num_classes, and in ascending order (e.g. [0, 0, 1, 1, 2]). So now we have a dataset
-    #     # where the row-sum of X is correlated with the class label (i.e. smaller row-sum is more
-    #     # likely to belong to class 0, and big row-sum is more likely to belong to class >0)
-    #     y_indices = (
-    #         np.digitize(np.arange(0, 1, 1 / num_samples), np.arange(0, 1, 1 / num_classes)) - 1
-    #     )
+        # Next we create an array which contains all class labels, multiple times if num_samples <
+        # num_classes, and in ascending order (e.g. [0, 0, 1, 1, 2]). So now we have a dataset
+        # where the row-sum of X is correlated with the class label (i.e. smaller row-sum is more
+        # likely to belong to class 0, and big row-sum is more likely to belong to class >0)
+        y_indices = (
+            np.digitize(np.arange(0, 1, 1 / num_samples), np.arange(0, 1, 1 / num_classes)) - 1
+        )
 
-    #     # Third, we random shuffle both X and y_indices
-    #     permutation = np.random.permutation(np.arange(num_samples))
-    #     X = X[permutation]
-    #     y_indices = y_indices[permutation]
+        # Third, we random shuffle both X and y_indices
+        permutation = np.random.permutation(np.arange(num_samples))
+        X = X[permutation]
+        y_indices = y_indices[permutation]
 
-    #     # Lastly we create a 1-hot label matrix y
-    #     y = np.zeros((num_samples, num_classes))
-    #     for e, index in enumerate(y_indices):
-    #         y[e, index] = 1
+        # Lastly we create a 1-hot label matrix y
+        y = np.zeros((num_samples, num_classes))
+        for e, index in enumerate(y_indices):
+            y[e, index] = 1
 
-    #     # fit to data
-    #     classifier.fit(X, y)
+        # fit to data
+        classifier.fit(X, y)
 
-    #     # score
-    #     score = classifier.score(X, y)
-    #     self.assertGreater(score, 1 / num_classes)
+        # score
+        score = classifier.score(X, y)
+        self.assertGreater(score, 1 / num_classes)
 
-    # @data(
-    #     # optimizer, quantum instance
-    #     ("cobyla", "statevector"),
-    #     ("cobyla", "qasm"),
-    #     ("bfgs", "statevector"),
-    #     ("bfgs", "qasm"),
-    #     (None, "statevector"),
-    #     (None, "qasm"),
-    # )
-    # def test_warm_start(self, config):
-    #     """Test VQC with warm_start=True."""
-    #     opt, q_i = config
+    @data(
+        # optimizer, quantum instance
+        ("cobyla", "statevector"),
+        ("cobyla", "qasm"),
+        ("bfgs", "statevector"),
+        ("bfgs", "qasm"),
+        (None, "statevector"),
+        (None, "qasm"),
+    )
+    def test_warm_start(self, config):
+        """Test VQC with warm_start=True."""
+        opt, q_i = config
 
-    #     if q_i == "statevector":
-    #         quantum_instance = self.sv_quantum_instance
-    #     else:
-    #         quantum_instance = self.qasm_quantum_instance
+        if q_i == "statevector":
+            quantum_instance = self.sv_quantum_instance
+        else:
+            quantum_instance = self.qasm_quantum_instance
 
-    #     if opt == "bfgs":
-    #         optimizer = L_BFGS_B(maxiter=5)
-    #     elif opt == "cobyla":
-    #         optimizer = COBYLA(maxiter=25)
-    #     else:
-    #         optimizer = None
+        if opt == "bfgs":
+            optimizer = L_BFGS_B(maxiter=5)
+        elif opt == "cobyla":
+            optimizer = COBYLA(maxiter=25)
+        else:
+            optimizer = None
 
-    #     num_inputs = 2
-    #     feature_map = ZZFeatureMap(num_inputs)
-    #     ansatz = RealAmplitudes(num_inputs, reps=1)
+        num_inputs = 2
+        feature_map = ZZFeatureMap(num_inputs)
+        ansatz = RealAmplitudes(num_inputs, reps=1)
 
-    #     # Construct the data.
-    #     num_samples = 10
-    #     # pylint: disable=invalid-name
-    #     X = algorithm_globals.random.random((num_samples, num_inputs))
-    #     y = 1.0 * (np.sum(X, axis=1) <= 1)
-    #     while len(np.unique(y)) == 1:
-    #         X = algorithm_globals.random.random((num_samples, num_inputs))
-    #         y = 1.0 * (np.sum(X, axis=1) <= 1)
-    #     y = np.array([y, 1 - y]).transpose()  # VQC requires one-hot encoded input.
+        # Construct the data.
+        num_samples = 10
+        # pylint: disable=invalid-name
+        X = algorithm_globals.random.random((num_samples, num_inputs))
+        y = 1.0 * (np.sum(X, axis=1) <= 1)
+        while len(np.unique(y)) == 1:
+            X = algorithm_globals.random.random((num_samples, num_inputs))
+            y = 1.0 * (np.sum(X, axis=1) <= 1)
+        y = np.array([y, 1 - y]).transpose()  # VQC requires one-hot encoded input.
 
-    #     # Initialize the VQC.
-    #     classifier = VQC(
-    #         feature_map=feature_map,
-    #         ansatz=ansatz,
-    #         optimizer=optimizer,
-    #         warm_start=True,
-    #         quantum_instance=quantum_instance,
-    #     )
+        # Initialize the VQC.
+        classifier = VQC(
+            feature_map=feature_map,
+            ansatz=ansatz,
+            optimizer=optimizer,
+            warm_start=True,
+            quantum_instance=quantum_instance,
+        )
 
-    #     # Fit the VQC to the first half of the data.
-    #     num_start = num_samples // 2
-    #     classifier.fit(X[:num_start, :], y[:num_start])
-    #     first_fit_final_point = classifier._fit_result.x
+        # Fit the VQC to the first half of the data.
+        num_start = num_samples // 2
+        classifier.fit(X[:num_start, :], y[:num_start])
+        first_fit_final_point = classifier._fit_result.x
 
-    #     # Fit the VQC to the second half of the data with a warm start.
-    #     classifier.fit(X[num_start:, :], y[num_start:])
-    #     second_fit_initial_point = classifier._initial_point
+        # Fit the VQC to the second half of the data with a warm start.
+        classifier.fit(X[num_start:, :], y[num_start:])
+        second_fit_initial_point = classifier._initial_point
 
-    #     # Check the final optimization point from the first fit was used to start the second fit.
-    #     np.testing.assert_allclose(first_fit_final_point, second_fit_initial_point)
+        # Check the final optimization point from the first fit was used to start the second fit.
+        np.testing.assert_allclose(first_fit_final_point, second_fit_initial_point)
 
-    #     # Check score.
-    #     score = classifier.score(X, y)
-    #     self.assertGreater(score, 0.5)
+        # Check score.
+        score = classifier.score(X, y)
+        self.assertGreater(score, 0.5)
 
     @data(
         # optimizer, quantum instance

--- a/test/algorithms/classifiers/test_vqc.py
+++ b/test/algorithms/classifiers/test_vqc.py
@@ -308,7 +308,7 @@ class TestVQC(QiskitMachineLearningTestCase):
         """Wrapper to record the number of classes assumed when building CircuitQNN."""
 
         @functools.wraps(func)
-        def wrapper(num_classes:int):
+        def wrapper(num_classes: int):
             self.num_classes_by_batch.append(num_classes)
             return func(num_classes)
 

--- a/test/algorithms/classifiers/test_vqc.py
+++ b/test/algorithms/classifiers/test_vqc.py
@@ -63,8 +63,10 @@ class TestVQC(QiskitMachineLearningTestCase):
 
         if q_i == "statevector":
             quantum_instance = self.sv_quantum_instance
-        else:
+        elif q_i == "qasm":
             quantum_instance = self.qasm_quantum_instance
+        else:
+            quantum_instance = None
 
         if opt == "bfgs":
             optimizer = L_BFGS_B(maxiter=5)
@@ -169,8 +171,10 @@ class TestVQC(QiskitMachineLearningTestCase):
 
         if q_i == "statevector":
             quantum_instance = self.sv_quantum_instance
-        else:
+        elif q_i == "qasm":
             quantum_instance = self.qasm_quantum_instance
+        else:
+            quantum_instance = None
 
         if opt == "bfgs":
             optimizer = L_BFGS_B(maxiter=5)
@@ -245,8 +249,10 @@ class TestVQC(QiskitMachineLearningTestCase):
 
         if q_i == "statevector":
             quantum_instance = self.sv_quantum_instance
-        else:
+        elif q_i == "qasm":
             quantum_instance = self.qasm_quantum_instance
+        else:
+            quantum_instance = None
 
         if opt == "bfgs":
             optimizer = L_BFGS_B(maxiter=5)
@@ -309,8 +315,10 @@ class TestVQC(QiskitMachineLearningTestCase):
 
         if q_i == "statevector":
             quantum_instance = self.sv_quantum_instance
-        else:
+        elif q_i == "qasm":
             quantum_instance = self.qasm_quantum_instance
+        else:
+            quantum_instance = None
 
         if opt == "bfgs":
             optimizer = L_BFGS_B(maxiter=5)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Closes #297. Currently, VQC will throw an error if trained on batches of data where not all of the target labels that can be found in the full dataset are present. This is because VQC interprets the number of unique labels in the current batch as the number of classes. 

Currently, VQC is hard-coded to expect one-hot encoded labels. Therefore, I suggest a small change to determine the number of classes from the shape of the label array. I have also edited the docstring to add the label encoding requirements of the current VQC implementation.

### Details and comments

Related issues that I will raise separately:
- I may also add a warning when running with a warm start and fitting to data with a different number of one-hot labels, as I would expect this to invalidate any previous fit.
- While multi-label classification is not supported, the code will not raise an error when it is provided; it might be beneficial to raise an error in such cases.
- In future, it might be good for VQC to accept different label encodings, in line with what an sklearn user might expect.
- It may simplify the unit tests to add objects directly to the dtd data decorator, rather than using string tags, as discussed by @woodsp-ibm on #312.