### PR TITLE
Deprecate some dataset functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,25 +46,25 @@ be classified.
 from qiskit import BasicAer
 from qiskit.utils import QuantumInstance, algorithm_globals
 from qiskit.algorithms.optimizers import COBYLA
-from qiskit.circuit.library import TwoLocal
+from qiskit.circuit.library import TwoLocal, ZZFeatureMap
 from qiskit_machine_learning.algorithms import VQC
-from qiskit_machine_learning.datasets import wine
-from qiskit_machine_learning.circuit.library import RawFeatureVector
+from qiskit_machine_learning.datasets import ad_hoc_data
 
 seed = 1376
 algorithm_globals.random_seed = seed
 
-# Use Wine data set for training and test data
-feature_dim = 4  # dimension of each data point
-training_size = 12
-test_size = 4
+# Use ad hoc data set for training and test data
+feature_dim = 2  # dimension of each data point
+training_size = 20
+test_size = 10
 
 # training features, training labels, test features, test labels as np.array,
 # one hot encoding for labels
 training_features, training_labels, test_features, test_labels = \
-    wine(training_size=training_size, test_size=test_size, n=feature_dim)
+    ad_hoc_data(
+            training_size=training_size, test_size=test_size, n=feature_dim, gap=0.3)
 
-feature_map = RawFeatureVector(feature_dimension=feature_dim)
+feature_map = ZZFeatureMap(feature_dimension=feature_dim, reps=2, entanglement="linear")
 ansatz = TwoLocal(feature_map.num_qubits, ['ry', 'rz'], 'cz', reps=3)
 vqc = VQC(feature_map=feature_map,
           ansatz=ansatz,

--- a/qiskit_machine_learning/datasets/breast_cancer.py
+++ b/qiskit_machine_learning/datasets/breast_cancer.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2021.
+# (C) Copyright IBM 2018, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -21,10 +21,15 @@ from sklearn.preprocessing import StandardScaler, MinMaxScaler
 from sklearn.decomposition import PCA
 from qiskit.exceptions import MissingOptionalLibraryError
 from .dataset_helper import features_and_labels_transform
+from ..deprecation import deprecate_function
 
 
+@deprecate_function("0.4.0")
 def breast_cancer(training_size, test_size, n, plot_data=False, one_hot=True):
-    """returns breast cancer dataset"""
+    """
+    Returns breast cancer dataset.
+    This function is deprecated in version 0.4.0
+    """
     class_labels = [r"A", r"B"]
     data, target = datasets.load_breast_cancer(return_X_y=True)
     sample_train, sample_test, label_train, label_test = train_test_split(

--- a/qiskit_machine_learning/datasets/digits.py
+++ b/qiskit_machine_learning/datasets/digits.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2021.
+# (C) Copyright IBM 2018, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -21,10 +21,15 @@ from sklearn.preprocessing import StandardScaler, MinMaxScaler
 from sklearn.decomposition import PCA
 from qiskit.exceptions import MissingOptionalLibraryError
 from .dataset_helper import features_and_labels_transform
+from ..deprecation import deprecate_function
 
 
+@deprecate_function("0.4.0")
 def digits(training_size, test_size, n, plot_data=False, one_hot=True):
-    """returns digits dataset"""
+    """
+    Returns digits dataset
+    This function is deprecated in version 0.4.0
+    """
     class_labels = [r"A", r"B", r"C", r"D", r"E", r"F", r"G", r"H", r"I", r"J"]
     data = datasets.load_digits()
     # pylint: disable=no-member

--- a/qiskit_machine_learning/datasets/gaussian.py
+++ b/qiskit_machine_learning/datasets/gaussian.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2021.
+# (C) Copyright IBM 2018, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -18,10 +18,15 @@ import numpy as np
 from qiskit.utils import algorithm_globals
 from qiskit.exceptions import MissingOptionalLibraryError
 from .dataset_helper import features_and_labels_transform
+from ..deprecation import deprecate_function
 
 
+@deprecate_function("0.4.0")
 def gaussian(training_size, test_size, n, plot_data=False, one_hot=True):
-    """returns gaussian dataset"""
+    """
+    Returns gaussian dataset.
+    This function is deprecated in version 0.4.0
+    """
     sigma = 1
     if n == 2:
         class_labels = [r"A", r"B"]

--- a/qiskit_machine_learning/datasets/iris.py
+++ b/qiskit_machine_learning/datasets/iris.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2021.
+# (C) Copyright IBM 2018, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -21,10 +21,15 @@ from sklearn.preprocessing import StandardScaler, MinMaxScaler
 from sklearn.decomposition import PCA
 from qiskit.exceptions import MissingOptionalLibraryError
 from .dataset_helper import features_and_labels_transform
+from ..deprecation import deprecate_function
 
 
+@deprecate_function("0.4.0")
 def iris(training_size, test_size, n, plot_data=False, one_hot=True):
-    """returns iris dataset"""
+    """
+    Returns iris dataset.
+    This function is deprecated in version 0.4.0
+    """
     class_labels = [r"A", r"B", r"C"]
     data, target = datasets.load_iris(return_X_y=True)
     sample_train, sample_test, label_train, label_test = train_test_split(

--- a/qiskit_machine_learning/datasets/wine.py
+++ b/qiskit_machine_learning/datasets/wine.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2021.
+# (C) Copyright IBM 2018, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -21,10 +21,15 @@ from sklearn.preprocessing import StandardScaler, MinMaxScaler
 from sklearn.decomposition import PCA
 from qiskit.exceptions import MissingOptionalLibraryError
 from .dataset_helper import features_and_labels_transform
+from ..deprecation import deprecate_function
 
 
+@deprecate_function("0.4.0")
 def wine(training_size, test_size, n, plot_data=False, one_hot=True):
-    """returns wine dataset"""
+    """
+    Returns wine dataset.
+    This function is deprecated in version 0.4.0
+    """
     class_labels = [r"A", r"B", r"C"]
 
     data, target = datasets.load_wine(return_X_y=True)

--- a/releasenotes/notes/deprecate-datasets-a2337ca0238faebb.yaml
+++ b/releasenotes/notes/deprecate-datasets-a2337ca0238faebb.yaml
@@ -1,0 +1,5 @@
+---
+deprecations:
+  - |
+    The functions `breast_cancer`, `digits`, `gaussian`, `iris` and `wine` in the `datasets` module are deprecated and
+    should not be used.

--- a/test/datasets/__init__.py
+++ b/test/datasets/__init__.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2021.
+# (C) Copyright IBM 2021, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -9,3 +9,13 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
+
+""" Test datasets module """
+
+
+def get_deprecated_msg_ref(function_name: str) -> str:
+    """returns reference deprecated message"""
+    return (
+        f"The {function_name} function is deprecated as of version 0.4.0 and "
+        "will be removed no sooner than 3 months after the release."
+    )

--- a/test/datasets/test_breast_cancer.py
+++ b/test/datasets/test_breast_cancer.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2021.
+# (C) Copyright IBM 2020, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -14,6 +14,8 @@
 
 import unittest
 from test import QiskitMachineLearningTestCase
+from test.datasets import get_deprecated_msg_ref
+import warnings
 import json
 import numpy as np
 from qiskit_machine_learning.datasets import breast_cancer
@@ -25,19 +27,27 @@ class TestBreastCancer(QiskitMachineLearningTestCase):
     def test_breast_cancer(self):
         """Breast Cancer test."""
 
-        input_file = self.get_resource_path("breast_cancer_ref.json", "datasets")
-        with open(input_file, encoding="utf8") as file:
-            ref_data = json.load(file)
+        with warnings.catch_warnings(record=True) as c_m:
+            warnings.simplefilter("always")
+            input_file = self.get_resource_path("breast_cancer_ref.json", "datasets")
+            with open(input_file, encoding="utf8") as file:
+                ref_data = json.load(file)
 
-        training_features, training_labels, test_features, test_labels = breast_cancer(
-            training_size=20, test_size=10, n=2, plot_data=False
-        )
+            training_features, training_labels, test_features, test_labels = breast_cancer(
+                training_size=20, test_size=10, n=2, plot_data=False
+            )
+            with self.subTest("Test training_features"):
+                np.testing.assert_almost_equal(ref_data["training_features"], training_features)
+            with self.subTest("Test training_labels"):
+                np.testing.assert_almost_equal(ref_data["training_labels"], training_labels)
+            with self.subTest("Test test_features"):
+                np.testing.assert_almost_equal(ref_data["test_features"], test_features)
+            with self.subTest("Test test_labels"):
+                np.testing.assert_array_equal(ref_data["test_labels"], test_labels)
 
-        np.testing.assert_almost_equal(ref_data["training_features"], training_features)
-        np.testing.assert_almost_equal(ref_data["training_labels"], training_labels)
-
-        np.testing.assert_almost_equal(ref_data["test_features"], test_features)
-        np.testing.assert_array_equal(ref_data["test_labels"], test_labels)
+        with self.subTest("Test deprecation msg"):
+            msg = str(c_m[0].message)
+            self.assertEqual(msg, get_deprecated_msg_ref("breast_cancer"))
 
 
 if __name__ == "__main__":

--- a/test/datasets/test_digits.py
+++ b/test/datasets/test_digits.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2021.
+# (C) Copyright IBM 2020, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -14,6 +14,8 @@
 
 import unittest
 from test import QiskitMachineLearningTestCase
+from test.datasets import get_deprecated_msg_ref
+import warnings
 import json
 import numpy as np
 from qiskit_machine_learning.datasets import digits
@@ -25,19 +27,27 @@ class TestDigits(QiskitMachineLearningTestCase):
     def test_digits(self):
         """Digits test."""
 
-        input_file = self.get_resource_path("digits_ref.json", "datasets")
-        with open(input_file, encoding="utf8") as file:
-            ref_data = json.load(file)
+        with warnings.catch_warnings(record=True) as c_m:
+            warnings.simplefilter("always")
+            input_file = self.get_resource_path("digits_ref.json", "datasets")
+            with open(input_file, encoding="utf8") as file:
+                ref_data = json.load(file)
 
-        training_features, training_labels, test_features, test_labels = digits(
-            training_size=20, test_size=10, n=2, plot_data=False
-        )
+            training_features, training_labels, test_features, test_labels = digits(
+                training_size=20, test_size=10, n=2, plot_data=False
+            )
+            with self.subTest("Test training_features"):
+                np.testing.assert_almost_equal(ref_data["training_features"], training_features, 4)
+            with self.subTest("Test training_labels"):
+                np.testing.assert_almost_equal(ref_data["training_labels"], training_labels, 4)
+            with self.subTest("Test test_features"):
+                np.testing.assert_almost_equal(ref_data["test_features"], test_features, 3)
+            with self.subTest("Test test_labels"):
+                np.testing.assert_almost_equal(ref_data["test_labels"], test_labels, 4)
 
-        np.testing.assert_almost_equal(ref_data["training_features"], training_features, 4)
-        np.testing.assert_almost_equal(ref_data["training_labels"], training_labels, 4)
-
-        np.testing.assert_almost_equal(ref_data["test_features"], test_features, 3)
-        np.testing.assert_almost_equal(ref_data["test_labels"], test_labels, 4)
+        with self.subTest("Test deprecation msg"):
+            msg = str(c_m[0].message)
+            self.assertEqual(msg, get_deprecated_msg_ref("digits"))
 
 
 if __name__ == "__main__":

--- a/test/datasets/test_gaussian.py
+++ b/test/datasets/test_gaussian.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2021.
+# (C) Copyright IBM 2020, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -14,6 +14,8 @@
 
 import unittest
 from test import QiskitMachineLearningTestCase
+from test.datasets import get_deprecated_msg_ref
+import warnings
 import numpy as np
 from qiskit_machine_learning.datasets import gaussian
 
@@ -24,20 +26,31 @@ class TestGaussian(QiskitMachineLearningTestCase):
     def test_gaussian(self):
         """Gaussian test."""
 
-        training_features, training_labels, test_features, test_labels = gaussian(
-            training_size=20, test_size=10, n=2, plot_data=False
-        )
-        np.testing.assert_array_equal(training_features.shape, (40, 2))
-        np.testing.assert_array_equal(training_labels.shape, (40, 2))
+        with warnings.catch_warnings(record=True) as c_m:
+            warnings.simplefilter("always")
+            training_features, training_labels, test_features, test_labels = gaussian(
+                training_size=20, test_size=10, n=2, plot_data=False
+            )
+            with self.subTest("Test training_features"):
+                np.testing.assert_array_equal(training_features.shape, (40, 2))
+            with self.subTest("Test training_labels1"):
+                np.testing.assert_array_equal(training_labels.shape, (40, 2))
+            with self.subTest("Test training_labels2"):
+                np.testing.assert_array_equal(np.sum(training_labels, axis=0), np.array([20, 20]))
+            with self.subTest("Test training_labels3"):
+                np.testing.assert_array_equal(np.sum(training_labels, axis=1), np.ones(40))
+            with self.subTest("Test features.shape1"):
+                np.testing.assert_array_equal(test_features.shape, (20, 2))
+            with self.subTest("Test features.shape2"):
+                np.testing.assert_array_equal(test_features.shape, (20, 2))
+            with self.subTest("Test test_labels1"):
+                np.testing.assert_array_equal(np.sum(test_labels, axis=0), np.array([10, 10]))
+            with self.subTest("Test test_labels2"):
+                np.testing.assert_array_equal(np.sum(test_labels, axis=1), np.ones(20))
 
-        np.testing.assert_array_equal(np.sum(training_labels, axis=0), np.array([20, 20]))
-        np.testing.assert_array_equal(np.sum(training_labels, axis=1), np.ones(40))
-
-        np.testing.assert_array_equal(test_features.shape, (20, 2))
-        np.testing.assert_array_equal(test_features.shape, (20, 2))
-
-        np.testing.assert_array_equal(np.sum(test_labels, axis=0), np.array([10, 10]))
-        np.testing.assert_array_equal(np.sum(test_labels, axis=1), np.ones(20))
+        with self.subTest("Test deprecation msg"):
+            msg = str(c_m[0].message)
+            self.assertEqual(msg, get_deprecated_msg_ref("gaussian"))
 
 
 if __name__ == "__main__":

--- a/test/datasets/test_iris.py
+++ b/test/datasets/test_iris.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2021.
+# (C) Copyright IBM 2020, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -14,6 +14,8 @@
 
 import unittest
 from test import QiskitMachineLearningTestCase
+from test.datasets import get_deprecated_msg_ref
+import warnings
 import json
 import numpy as np
 from qiskit_machine_learning.datasets import iris
@@ -25,19 +27,27 @@ class TestIris(QiskitMachineLearningTestCase):
     def test_iris(self):
         """Iris test."""
 
-        input_file = self.get_resource_path("iris_ref.json", "datasets")
-        with open(input_file, encoding="utf8") as file:
-            ref_data = json.load(file)
+        with warnings.catch_warnings(record=True) as c_m:
+            warnings.simplefilter("always")
+            input_file = self.get_resource_path("iris_ref.json", "datasets")
+            with open(input_file, encoding="utf8") as file:
+                ref_data = json.load(file)
 
-        training_features, training_labels, test_features, test_labels = iris(
-            training_size=20, test_size=3, n=2, plot_data=False
-        )
+            training_features, training_labels, test_features, test_labels = iris(
+                training_size=20, test_size=3, n=2, plot_data=False
+            )
+            with self.subTest("Test training_features"):
+                np.testing.assert_almost_equal(ref_data["training_features"], training_features)
+            with self.subTest("Test training_labels"):
+                np.testing.assert_almost_equal(ref_data["training_labels"], training_labels)
+            with self.subTest("Test test_features"):
+                np.testing.assert_almost_equal(ref_data["test_features"], test_features)
+            with self.subTest("Test test_labels"):
+                np.testing.assert_almost_equal(ref_data["test_labels"], test_labels)
 
-        np.testing.assert_almost_equal(ref_data["training_features"], training_features)
-        np.testing.assert_almost_equal(ref_data["training_labels"], training_labels)
-
-        np.testing.assert_almost_equal(ref_data["test_features"], test_features)
-        np.testing.assert_almost_equal(ref_data["test_labels"], test_labels)
+        with self.subTest("Test deprecation msg"):
+            msg = str(c_m[0].message)
+            self.assertEqual(msg, get_deprecated_msg_ref("iris"))
 
 
 if __name__ == "__main__":

--- a/test/datasets/test_wine.py
+++ b/test/datasets/test_wine.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2021.
+# (C) Copyright IBM 2020, 2022.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -14,6 +14,8 @@
 
 import unittest
 from test import QiskitMachineLearningTestCase
+from test.datasets import get_deprecated_msg_ref
+import warnings
 import json
 import numpy as np
 from qiskit_machine_learning.datasets import wine
@@ -25,19 +27,27 @@ class TestWine(QiskitMachineLearningTestCase):
     def test_wine(self):
         """Wine test."""
 
-        input_file = self.get_resource_path("wine_ref.json", "datasets")
-        with open(input_file, encoding="utf8") as file:
-            ref_data = json.load(file)
+        with warnings.catch_warnings(record=True) as c_m:
+            warnings.simplefilter("always")
+            input_file = self.get_resource_path("wine_ref.json", "datasets")
+            with open(input_file, encoding="utf8") as file:
+                ref_data = json.load(file)
 
-        training_features, training_labels, test_features, test_labels = wine(
-            training_size=20, test_size=10, n=2, plot_data=False, one_hot=False
-        )
+            training_features, training_labels, test_features, test_labels = wine(
+                training_size=20, test_size=10, n=2, plot_data=False, one_hot=False
+            )
+            with self.subTest("Test training_features"):
+                np.testing.assert_almost_equal(ref_data["training_features"], training_features)
+            with self.subTest("Test training_labels"):
+                np.testing.assert_almost_equal(ref_data["training_labels"], training_labels)
+            with self.subTest("Test test_features"):
+                np.testing.assert_almost_equal(ref_data["test_features"], test_features)
+            with self.subTest("Test test_labels"):
+                np.testing.assert_almost_equal(ref_data["test_labels"], test_labels)
 
-        np.testing.assert_almost_equal(ref_data["training_features"], training_features)
-        np.testing.assert_almost_equal(ref_data["training_labels"], training_labels)
-
-        np.testing.assert_almost_equal(ref_data["test_features"], test_features)
-        np.testing.assert_almost_equal(ref_data["test_labels"], test_labels)
+        with self.subTest("Test deprecation msg"):
+            msg = str(c_m[0].message)
+            self.assertEqual(msg, get_deprecated_msg_ref("wine"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Deprecate all dataset functions but `ad_hoc_data` still used by tutorials.


### Details and comments


