### PR TITLE
Add support for sparse arrays in QNN-based classifiers

### DIFF
--- a/qiskit_machine_learning/algorithms/classifiers/neural_network_classifier.py
+++ b/qiskit_machine_learning/algorithms/classifiers/neural_network_classifier.py
@@ -11,10 +11,12 @@
 # that they have been altered from the originals.
 """An implementation of quantum neural network classifier."""
 
-from typing import Union, Optional, Callable
+from typing import Union, Optional, Callable, Tuple, cast
 
 import numpy as np
+import scipy.sparse
 from qiskit.algorithms.optimizers import Optimizer
+from scipy.sparse import spmatrix
 from sklearn.base import ClassifierMixin
 from sklearn.preprocessing import OneHotEncoder, LabelEncoder
 
@@ -86,7 +88,8 @@ class NeuralNetworkClassifier(TrainableModel, ClassifierMixin):
         self._target_encoder = OneHotEncoder(sparse=False) if one_hot else LabelEncoder()
 
     def fit(self, X: np.ndarray, y: np.ndarray):  # pylint: disable=invalid-name
-        y = self._fit_and_encode_labels(y)
+        self._fit_result = None
+        X, y = self._validate_input(X, y)
 
         # mypy definition
         function: ObjectiveFunction = None
@@ -114,6 +117,9 @@ class NeuralNetworkClassifier(TrainableModel, ClassifierMixin):
     def predict(self, X: np.ndarray) -> np.ndarray:  # pylint: disable=invalid-name
         if self._fit_result is None:
             raise QiskitMachineLearningError("Model needs to be fit to some training data first!")
+
+        X, _ = self._validate_input(X)
+
         if self._neural_network.output_shape == (1,):
             predict = np.sign(self._neural_network.forward(X, self._fit_result.x))
         else:
@@ -131,32 +137,39 @@ class NeuralNetworkClassifier(TrainableModel, ClassifierMixin):
     def score(
         self, X: np.ndarray, y: np.ndarray, sample_weight: Optional[np.ndarray] = None
     ) -> float:
-        y = self._encode_labels(y)
+        X, y = self._validate_input(X, y)
         return ClassifierMixin.score(self, X, y, sample_weight)
 
-    def _fit_and_encode_labels(self, y: np.ndarray) -> np.ndarray:
-        """Fits label or one-hot encoder and converts categorical target data."""
+    def _validate_input(self, X: np.ndarray, y: np.ndarray = None) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        Prepares features and labels. If arrays are sparse, they are converted to dense as the numpy
+        math in the loss/objective functions does not work with sparse. If one hot encoding is
+        required, then labels are one hot encoded otherwise label are encoded via ``LabelEncoder``
+        from ``SciKit-Learn``. If labels are strings, they converted to numerical representation.
 
-        if isinstance(y[0], str):
-            # string data is assumed to be categorical
+        Args:
+            X: features
+            y: labels
 
-            # OneHotEncoder expects data with shape (n_samples, n_features) but
-            # LabelEncoder expects shape (n_samples,) so set desired shape
-            y = y.reshape(-1, 1) if self._one_hot else y
-            self._target_encoder.fit(y)
-            y = self._target_encoder.transform(y)
+        Returns:
+            A tuple with prepared features and labels.
+        """
+        if scipy.sparse.issparse(X):
+            # our math does not work with sparse arrays
+            X = np.array(cast(spmatrix, X).todense())  # cast is required by mypy
 
-        return y
+        if y is not None:
+            if isinstance(y[0], str):
+                # string data is assumed to be categorical
 
-    def _encode_labels(self, y: np.ndarray) -> np.ndarray:
-        """Converts categorical target data using label or one-hot encoding."""
+                # OneHotEncoder expects data with shape (n_samples, n_features) but
+                # LabelEncoder expects shape (n_samples,) so set desired shape
+                y = y.reshape(-1, 1) if self._one_hot else y
+                if self._fit_result is None:
+                    # the model is being trained, fit first
+                    self._target_encoder.fit(y)
+                y = self._target_encoder.transform(y)
+            elif scipy.sparse.issparse(y):
+                y = np.array(cast(spmatrix, y).todense())  # cast is required by mypy
 
-        if isinstance(y[0], str):
-            # string data is assumed to be categorical
-
-            # OneHotEncoder expects data with shape (n_samples, n_features) but
-            # LabelEncoder expects shape (n_samples,) so set desired shape
-            y = y.reshape(-1, 1) if self._one_hot else y
-            y = self._target_encoder.transform(y)
-
-        return y
+        return X, y

--- a/releasenotes/notes/sparse-bug-a51b5a2a1edb06eb.yaml
+++ b/releasenotes/notes/sparse-bug-a51b5a2a1edb06eb.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixed a bug when a sparse array is passed to ``VQC`` as labels. Sparse arrays can be easily
+    observed when labels are encoded via ``OneHotEncoder`` from ``SciKit-Learn``. Now both
+    ``NeuralNetworkClassifier`` and ``VQC`` support sparse arrays and convert them dense arrays in
+    the implementation.

--- a/test/algorithms/classifiers/test_neural_network_classifier.py
+++ b/test/algorithms/classifiers/test_neural_network_classifier.py
@@ -16,10 +16,14 @@ import unittest
 
 from test import QiskitMachineLearningTestCase
 
+from typing import Tuple, Optional, Callable
+
+import scipy.sparse
+
 import numpy as np
 from ddt import ddt, data
 from qiskit import Aer, QuantumCircuit
-from qiskit.algorithms.optimizers import COBYLA, L_BFGS_B
+from qiskit.algorithms.optimizers import COBYLA, L_BFGS_B, Optimizer
 from qiskit.circuit.library import RealAmplitudes, ZZFeatureMap
 from qiskit.utils import QuantumInstance, algorithm_globals
 
@@ -133,6 +137,63 @@ class TestNeuralNetworkClassifier(QiskitMachineLearningTestCase):
                 self.assertEqual(len(weights), qnn.num_weights)
                 self.assertTrue(all(isinstance(weight, float) for weight in weights))
 
+    def _create_circuit_qnn(self, quantum_instance: QuantumInstance) -> Tuple[CircuitQNN, int, int]:
+        num_inputs = 2
+        feature_map = ZZFeatureMap(num_inputs)
+        ansatz = RealAmplitudes(num_inputs, reps=1)
+
+        # construct circuit
+        qc = QuantumCircuit(num_inputs)
+        qc.append(feature_map, range(2))
+        qc.append(ansatz, range(2))
+
+        # construct qnn
+        def parity(x):
+            return f"{x:b}".count("1") % 2
+
+        output_shape = 2
+        qnn = CircuitQNN(
+            qc,
+            input_params=feature_map.parameters,
+            weight_params=ansatz.parameters,
+            sparse=False,
+            interpret=parity,
+            output_shape=output_shape,
+            quantum_instance=quantum_instance,
+        )
+
+        return qnn, num_inputs, ansatz.num_parameters
+
+    def _generate_data(self, num_inputs: int) -> Tuple[np.ndarray, np.ndarray]:
+        # construct data
+        num_samples = 5
+        features = algorithm_globals.random.random((num_samples, num_inputs))
+        labels = 1.0 * (np.sum(features, axis=1) <= 1)
+
+        return features, labels
+
+    def _create_classifier(
+        self,
+        qnn: CircuitQNN,
+        num_parameters: int,
+        optimizer: Optimizer,
+        loss: str,
+        callback: Optional[Callable[[np.ndarray, float], None]] = None,
+        one_hot: bool = False,
+    ):
+        initial_point = np.array([0.5] * num_parameters)
+
+        # construct classifier
+        classifier = NeuralNetworkClassifier(
+            qnn,
+            optimizer=optimizer,
+            loss=loss,
+            one_hot=one_hot,
+            initial_point=initial_point,
+            callback=callback,
+        )
+        return classifier
+
     @data(
         # optimizer, loss, quantum instance
         ("cobyla", "absolute_error", "statevector", False),
@@ -187,48 +248,17 @@ class TestNeuralNetworkClassifier(QiskitMachineLearningTestCase):
         else:
             callback = None
 
-        num_inputs = 2
-        feature_map = ZZFeatureMap(num_inputs)
-        ansatz = RealAmplitudes(num_inputs, reps=1)
+        qnn, num_inputs, num_parameters = self._create_circuit_qnn(quantum_instance)
 
-        # construct circuit
-        qc = QuantumCircuit(num_inputs)
-        qc.append(feature_map, range(2))
-        qc.append(ansatz, range(2))
+        classifier = self._create_classifier(qnn, num_parameters, optimizer, loss, callback)
 
-        # construct qnn
-        def parity(x):
-            return f"{x:b}".count("1") % 2
-
-        output_shape = 2
-        qnn = CircuitQNN(
-            qc,
-            input_params=feature_map.parameters,
-            weight_params=ansatz.parameters,
-            sparse=False,
-            interpret=parity,
-            output_shape=output_shape,
-            quantum_instance=quantum_instance,
-        )
-        initial_point = np.array([0.5] * ansatz.num_parameters)
-
-        # construct classifier
-        classifier = NeuralNetworkClassifier(
-            qnn, optimizer=optimizer, loss=loss, initial_point=initial_point, callback=callback
-        )
-
-        # construct data
-        num_samples = 5
-        X = algorithm_globals.random.random(  # pylint: disable=invalid-name
-            (num_samples, num_inputs)
-        )
-        y = 1.0 * (np.sum(X, axis=1) <= 1)
+        features, labels = self._generate_data(num_inputs)
 
         # fit to data
-        classifier.fit(X, y)
+        classifier.fit(features, labels)
 
         # score
-        score = classifier.score(X, y)
+        score = classifier.score(features, labels)
         self.assertGreater(score, 0.5)
 
         # callback
@@ -276,54 +306,18 @@ class TestNeuralNetworkClassifier(QiskitMachineLearningTestCase):
 
         loss = CrossEntropyLoss()
 
-        num_inputs = 2
-        feature_map = ZZFeatureMap(num_inputs)
-        ansatz = RealAmplitudes(num_inputs, reps=1)
+        qnn, num_inputs, num_parameters = self._create_circuit_qnn(quantum_instance)
 
-        # construct circuit
-        qc = QuantumCircuit(num_inputs)
-        qc.append(feature_map, range(2))
-        qc.append(ansatz, range(2))
+        classifier = self._create_classifier(qnn, num_parameters, optimizer, loss, callback, True)
 
-        # construct qnn
-        def parity(x):
-            return f"{x:b}".count("1") % 2
-
-        output_shape = 2
-        qnn = CircuitQNN(
-            qc,
-            input_params=feature_map.parameters,
-            weight_params=ansatz.parameters,
-            sparse=False,
-            interpret=parity,
-            output_shape=output_shape,
-            quantum_instance=quantum_instance,
-        )
-        # classification may fail sometimes, so let's fix initial point
-        initial_point = np.array([0.5] * ansatz.num_parameters)
-        # construct classifier - note: CrossEntropy requires eval_probabilities=True!
-        classifier = NeuralNetworkClassifier(
-            qnn,
-            optimizer=optimizer,
-            loss=loss,
-            one_hot=True,
-            initial_point=initial_point,
-            callback=callback,
-        )
-
-        # construct data
-        num_samples = 5
-        X = algorithm_globals.random.random(  # pylint: disable=invalid-name
-            (num_samples, num_inputs)
-        )
-        y = 1.0 * (np.sum(X, axis=1) <= 1)
-        y = np.array([y, 1 - y]).transpose()
+        features, labels = self._generate_data(num_inputs)
+        labels = np.array([labels, 1 - labels]).transpose()
 
         # fit to data
-        classifier.fit(X, y)
+        classifier.fit(features, labels)
 
         # score
-        score = classifier.score(X, y)
+        score = classifier.score(features, labels)
         self.assertGreater(score, 0.5)
 
         # callback
@@ -349,52 +343,45 @@ class TestNeuralNetworkClassifier(QiskitMachineLearningTestCase):
         quantum_instance = self.sv_quantum_instance
         optimizer = L_BFGS_B(maxiter=5)
 
-        num_inputs = 2
-        feature_map = ZZFeatureMap(num_inputs)
-        ansatz = RealAmplitudes(num_inputs, reps=1)
+        qnn, num_inputs, num_parameters = self._create_circuit_qnn(quantum_instance)
 
-        # construct circuit
-        qc = QuantumCircuit(num_inputs)
-        qc.append(feature_map, range(2))
-        qc.append(ansatz, range(2))
+        classifier = self._create_classifier(qnn, num_parameters, optimizer, loss, one_hot=one_hot)
 
-        # construct qnn
-        def parity(x):
-            return f"{x:b}".count("1") % 2
-
-        output_shape = 2
-        qnn = CircuitQNN(
-            qc,
-            input_params=feature_map.parameters,
-            weight_params=ansatz.parameters,
-            sparse=False,
-            interpret=parity,
-            output_shape=output_shape,
-            quantum_instance=quantum_instance,
-        )
-        initial_point = np.array([0.5] * ansatz.num_parameters)
-
-        # construct classifier
-        classifier = NeuralNetworkClassifier(
-            qnn, optimizer=optimizer, loss=loss, initial_point=initial_point, one_hot=one_hot
-        )
-
-        # construct data
-        num_samples = 5
-        X = algorithm_globals.random.random(  # pylint: disable=invalid-name
-            (num_samples, num_inputs)
-        )
-        y = 1.0 * (np.sum(X, axis=1) <= 1)
-        y = y.astype(str)
+        features, labels = self._generate_data(num_inputs)
+        labels = labels.astype(str)
         # convert to categorical
-        y[y == "0.0"] = "A"
-        y[y == "1.0"] = "B"
+        labels[labels == "0.0"] = "A"
+        labels[labels == "1.0"] = "B"
 
         # fit to data
-        classifier.fit(X, y)
+        classifier.fit(features, labels)
 
         # score
-        score = classifier.score(X, y)
+        score = classifier.score(features, labels)
+        self.assertGreater(score, 0.5)
+
+    def test_sparse_arrays(self):
+        """Tests classifier with sparse arrays as features and labels."""
+        for quantum_instance in [self.sv_quantum_instance, self.qasm_quantum_instance]:
+            for loss in ["squared_error", "absolute_error", "cross_entropy"]:
+                with self.subTest(f"quantum_instance: {quantum_instance}, loss: {loss}"):
+                    self._test_sparse_arrays(quantum_instance, loss)
+
+    def _test_sparse_arrays(self, quantum_instance: QuantumInstance, loss: str):
+        optimizer = L_BFGS_B(maxiter=5)
+
+        qnn, _, num_parameters = self._create_circuit_qnn(quantum_instance)
+
+        classifier = self._create_classifier(qnn, num_parameters, optimizer, loss, one_hot=True)
+
+        features = scipy.sparse.csr_matrix([[0, 0], [1, 1]])
+        labels = scipy.sparse.csr_matrix([[1, 0], [0, 1]])
+
+        # fit to data
+        classifier.fit(features, labels)
+
+        # score
+        score = classifier.score(features, labels)
         self.assertGreater(score, 0.5)
 
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Fixed a bug when a sparse array is passed to `VQC` as labels. Sparse arrays can be easily observed when labels are encoded via `OneHotEncoder` from `SciKit-Learn`. Now both `NeuralNetworkClassifier` and `VQC` support sparse arrays and convert them dense arrays in the implementation.


### Details and comments
A conversion taken place in `NeuralNetworkClassifer`. Initially, I was trying to add plain support of sparse arrays, but I realized that numpy math we have just does not work on sparse arrays and it is required quite a large re-work. While I don't expect huge sparse arrays, I propose just to have a conversion to dense representation.

Fixes #328.

