### PR TITLE
Remove usage of the "l2" loss in the tutorial

### DIFF
--- a/docs/tutorials/02_neural_network_classifier_and_regressor.ipynb
+++ b/docs/tutorials/02_neural_network_classifier_and_regressor.ipynb
@@ -610,7 +610,10 @@
    "source": [
     "# construct the regressor from the neural network\n",
     "regressor = NeuralNetworkRegressor(\n",
-    "    neural_network=regression_opflow_qnn, loss=\"l2\", optimizer=L_BFGS_B(), callback=callback_graph\n",
+    "    neural_network=regression_opflow_qnn,\n",
+    "    loss=\"squared_error\",\n",
+    "    optimizer=L_BFGS_B(),\n",
+    "    callback=callback_graph,\n",
     ")"
    ]
   },

--- a/qiskit_machine_learning/algorithms/trainable_model.py
+++ b/qiskit_machine_learning/algorithms/trainable_model.py
@@ -27,7 +27,6 @@ from qiskit_machine_learning.utils.loss_functions import (
     CrossEntropyLoss,
     CrossEntropySigmoidLoss,
 )
-from qiskit_machine_learning.deprecation import deprecate_values
 
 from .objective_functions import ObjectiveFunction
 
@@ -35,9 +34,6 @@ from .objective_functions import ObjectiveFunction
 class TrainableModel:
     """Base class for ML model. This class defines Scikit-Learn like interface to implement."""
 
-    @deprecate_values(
-        "0.2.0", {"loss": {"l1": "absolute_error", "l2": "squared_error"}}, stack_level=4
-    )
     def __init__(
         self,
         neural_network: NeuralNetwork,
@@ -89,10 +85,6 @@ class TrainableModel:
                 self._loss = CrossEntropyLoss()
             elif loss == "cross_entropy_sigmoid":
                 self._loss = CrossEntropySigmoidLoss()
-            elif loss == "l1":
-                self._loss = L1Loss()
-            elif loss == "l2":
-                self._loss = L2Loss()
             else:
                 raise QiskitMachineLearningError(f"Unknown loss {loss}!")
 

--- a/qiskit_machine_learning/algorithms/trainable_model.py
+++ b/qiskit_machine_learning/algorithms/trainable_model.py
@@ -27,6 +27,7 @@ from qiskit_machine_learning.utils.loss_functions import (
     CrossEntropyLoss,
     CrossEntropySigmoidLoss,
 )
+from qiskit_machine_learning.deprecation import deprecate_values
 
 from .objective_functions import ObjectiveFunction
 
@@ -34,6 +35,9 @@ from .objective_functions import ObjectiveFunction
 class TrainableModel:
     """Base class for ML model. This class defines Scikit-Learn like interface to implement."""
 
+    @deprecate_values(
+        "0.2.0", {"loss": {"l1": "absolute_error", "l2": "squared_error"}}, stack_level=4
+    )
     def __init__(
         self,
         neural_network: NeuralNetwork,
@@ -85,6 +89,10 @@ class TrainableModel:
                 self._loss = CrossEntropyLoss()
             elif loss == "cross_entropy_sigmoid":
                 self._loss = CrossEntropySigmoidLoss()
+            elif loss == "l1":
+                self._loss = L1Loss()
+            elif loss == "l2":
+                self._loss = L2Loss()
             else:
                 raise QiskitMachineLearningError(f"Unknown loss {loss}!")
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Remove the deprecated "l2" loss from the 02 tutorial

