### PR TITLE
fix typo `sin wave` > `sine wave`

### DIFF
--- a/docs/tutorials/06_torch_runtime.ipynb
+++ b/docs/tutorials/06_torch_runtime.ipynb
@@ -18,7 +18,7 @@
     "## 1. Regression\n",
     "\n",
     "First, we show how to use Torch Runtime via `TorchRuntimeClient` using the simple regression example. In the example, we will perform \n",
-    "a regression task on a randomly generated dataset following a sin wave."
+    "a regression task on a randomly generated dataset following a sine wave."
    ]
   },
   {


### PR DESCRIPTION
fix typo `sin wave` > `sine wave`
detected by Natália Capra Ferrazzo on crowdin (aka @nataliaferrazzo)

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


