### PR TITLE
Add tox env. gpu-amd for GPU linux tests with AMD

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.17
-envlist = py37, py38, py39, py310, lint, gpu
+envlist = py37, py38, py39, py310, lint, gpu, gpu-amd
 skipsdist = True
 
 [testenv]
@@ -28,6 +28,21 @@ deps =
   {[testenv]deps}
   qiskit-aer-gpu; sys_platform == 'linux'
 commands =
+  python3 {toxinidir}/tools/find_gpu_decorated_methods.py -path {temp_dir}/include_list.log
+  stestr run --include-list {temp_dir}/include_list.log {posargs}
+
+[testenv:gpu-amd]
+basepython = python3
+platform = linux
+setenv =
+  {[testenv]setenv}
+  QISKIT_GPU=true
+deps =
+  {[testenv]deps}
+  qiskit-aer-gpu; sys_platform == 'linux'
+extras = sparse
+commands =
+  pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/rocm4.5.2
   python3 {toxinidir}/tools/find_gpu_decorated_methods.py -path {temp_dir}/include_list.log
   stestr run --include-list {temp_dir}/include_list.log {posargs}
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Added an option to tox to run GPU tests for Linux machines with AMD cards.
Following the torch installation instructions, choosing:

1. PyTorch Build: Stable
2. OS: Linux
3. Package: Pip
4. Language: Python
5. Compute Platform:  ROCm 4.52 (beta)

at:  https://pytorch.org/get-started/locally/

List of supported AMD cards and OS at:
https://github.com/RadeonOpenCompute/ROCm

Drivers need to be installed in the supported OS following instructions at:
https://rocmdocs.amd.com/en/latest/Installation_Guide/Installation_new.html#rocm-installation-guide-v4-5

### Details and comments
![Screen Shot 2022-04-07 at 4 25 29 PM](https://user-images.githubusercontent.com/16138150/162290042-242016c2-a78c-4dbf-84b9-1df779885220.png)

NOTE: Verify from the output that the product field value matches the supported GPU Architecture in the table above.

