### PR TITLE
Average objective functions

### DIFF
--- a/qiskit_machine_learning/algorithms/trainable_model.py
+++ b/qiskit_machine_learning/algorithms/trainable_model.py
@@ -27,7 +27,6 @@ from qiskit_machine_learning.utils.loss_functions import (
     CrossEntropyLoss,
     CrossEntropySigmoidLoss,
 )
-from qiskit_machine_learning.deprecation import deprecate_values
 
 from .objective_functions import ObjectiveFunction
 
@@ -35,9 +34,6 @@ from .objective_functions import ObjectiveFunction
 class TrainableModel:
     """Base class for ML model. This class defines Scikit-Learn like interface to implement."""
 
-    @deprecate_values(
-        "0.2.0", {"loss": {"l1": "absolute_error", "l2": "squared_error"}}, stack_level=4
-    )
     def __init__(
         self,
         neural_network: NeuralNetwork,
@@ -89,10 +85,6 @@ class TrainableModel:
                 self._loss = CrossEntropyLoss()
             elif loss == "cross_entropy_sigmoid":
                 self._loss = CrossEntropySigmoidLoss()
-            elif loss == "l1":
-                self._loss = L1Loss()
-            elif loss == "l2":
-                self._loss = L2Loss()
             else:
                 raise QiskitMachineLearningError(f"Unknown loss {loss}!")
 

--- a/qiskit_machine_learning/algorithms/trainable_model.py
+++ b/qiskit_machine_learning/algorithms/trainable_model.py
@@ -27,6 +27,7 @@ from qiskit_machine_learning.utils.loss_functions import (
     CrossEntropyLoss,
     CrossEntropySigmoidLoss,
 )
+from qiskit_machine_learning.deprecation import deprecate_values
 
 from .objective_functions import ObjectiveFunction
 
@@ -34,6 +35,9 @@ from .objective_functions import ObjectiveFunction
 class TrainableModel:
     """Base class for ML model. This class defines Scikit-Learn like interface to implement."""
 
+    @deprecate_values(
+        "0.2.0", {"loss": {"l1": "absolute_error", "l2": "squared_error"}}, stack_level=4
+    )
     def __init__(
         self,
         neural_network: NeuralNetwork,
@@ -85,6 +89,10 @@ class TrainableModel:
                 self._loss = CrossEntropyLoss()
             elif loss == "cross_entropy_sigmoid":
                 self._loss = CrossEntropySigmoidLoss()
+            elif loss == "l1":
+                self._loss = L1Loss()
+            elif loss == "l2":
+                self._loss = L2Loss()
             else:
                 raise QiskitMachineLearningError(f"Unknown loss {loss}!")
 

--- a/releasenotes/notes/average-objective-a1faffb8a11307cc.yaml
+++ b/releasenotes/notes/average-objective-a1faffb8a11307cc.yaml
@@ -4,6 +4,5 @@ features:
     Objective functions constructed by the neural network classifiers and regressors now include an
     averaging factor that is evaluated as ``1 / number_of_samples``. Computed averaged objective
     values are passed to a user specified callback if any. Users may notice a dramatical
-    decrease in the objective values in their callbacks. This is due to the averaging factor applied
-    to objective functions.
+    decrease in the objective values in their callbacks. This is due to this averaging factor.
 

--- a/releasenotes/notes/average-objective-a1faffb8a11307cc.yaml
+++ b/releasenotes/notes/average-objective-a1faffb8a11307cc.yaml
@@ -1,0 +1,9 @@
+---
+features:
+  - |
+    Objective functions constructed by the neural network classifiers and regressors now include an
+    averaging factor that is evaluated as ``1 / number_of_samples``. Computed averaged objective
+    values are passed to a user specified callback if any. Users may notice a dramatical
+    decrease in the objective values in their callbacks. This is due to the averaging factor applied
+    to objective functions.
+

--- a/releasenotes/notes/average-objective-a1faffb8a11307cc.yaml
+++ b/releasenotes/notes/average-objective-a1faffb8a11307cc.yaml
@@ -3,6 +3,6 @@ features:
   - |
     Objective functions constructed by the neural network classifiers and regressors now include an
     averaging factor that is evaluated as ``1 / number_of_samples``. Computed averaged objective
-    values are passed to a user specified callback if any. Users may notice a dramatical
-    decrease in the objective values in their callbacks. This is due to this averaging factor.
+    values are passed to a user specified callback if any. Users may notice a dramatic decrease
+    in the objective values in their callbacks. This is due to this averaging factor.
 

--- a/test/algorithms/classifiers/test_neural_network_classifier.py
+++ b/test/algorithms/classifiers/test_neural_network_classifier.py
@@ -117,7 +117,7 @@ class TestNeuralNetworkClassifier(QiskitMachineLearningTestCase):
         )
 
         # construct data
-        num_samples = 5
+        num_samples = 6
         X = algorithm_globals.random.random(  # pylint: disable=invalid-name
             (num_samples, num_inputs)
         )
@@ -166,7 +166,7 @@ class TestNeuralNetworkClassifier(QiskitMachineLearningTestCase):
 
     def _generate_data(self, num_inputs: int) -> Tuple[np.ndarray, np.ndarray]:
         # construct data
-        num_samples = 5
+        num_samples = 6
         features = algorithm_globals.random.random((num_samples, num_inputs))
         labels = 1.0 * (np.sum(features, axis=1) <= 1)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Objective functions constructed by the neural network classifiers and regressors now include an averaging factor that is evaluated as `1 / number_of_samples`. Computed averaged objective values are passed to a user specified callback if any. Users may notice a dramatic decrease in the objective values in their callbacks. This is due to this averaging factor.
Closes #327.


### Details and comments
Updated:
- Objective functions
- Increased number of samples from 5 to 6 in the tests to improve test convergence and stability.
