### PR TITLE
Randomize file names in the model save/load tests

### DIFF
--- a/test/algorithms/classifiers/test_neural_network_classifier.py
+++ b/test/algorithms/classifiers/test_neural_network_classifier.py
@@ -314,7 +314,9 @@ class TestNeuralNetworkClassifier(QiskitMachineLearningTestCase):
         original_predicts = classifier.predict(test_features)
 
         # save/load, change the quantum instance and check if predicted values are the same
-        file_name = os.path.join(tempfile.gettempdir(), "classifier.model")
+        file_name = os.path.join(
+            tempfile.gettempdir(), "classifier" + str(np.random.randint(1000)) + ".model"
+        )
         classifier.save(file_name)
         try:
             classifier_load = NeuralNetworkClassifier.load(file_name)

--- a/test/algorithms/classifiers/test_neural_network_classifier.py
+++ b/test/algorithms/classifiers/test_neural_network_classifier.py
@@ -314,11 +314,10 @@ class TestNeuralNetworkClassifier(QiskitMachineLearningTestCase):
         original_predicts = classifier.predict(test_features)
 
         # save/load, change the quantum instance and check if predicted values are the same
-        file_name = os.path.join(
-            tempfile.gettempdir(), "classifier" + str(np.random.randint(1000)) + ".model"
-        )
-        classifier.save(file_name)
-        try:
+        with tempfile.TemporaryDirectory() as dir_name:
+            file_name = os.path.join(dir_name, "classifier.model")
+            classifier.save(file_name)
+
             classifier_load = NeuralNetworkClassifier.load(file_name)
             loaded_model_predicts = classifier_load.predict(test_features)
 
@@ -332,9 +331,6 @@ class TestNeuralNetworkClassifier(QiskitMachineLearningTestCase):
 
             with self.assertRaises(TypeError):
                 FakeModel.load(file_name)
-
-        finally:
-            os.remove(file_name)
 
 
 if __name__ == "__main__":

--- a/test/algorithms/regressors/test_neural_network_regressor.py
+++ b/test/algorithms/regressors/test_neural_network_regressor.py
@@ -155,7 +155,9 @@ class TestNeuralNetworkRegressor(QiskitMachineLearningTestCase):
         original_predicts = regressor.predict(test_features)
 
         # save/load, change the quantum instance and check if predicted values are the same
-        file_name = os.path.join(tempfile.gettempdir(), "regressor.model")
+        file_name = os.path.join(
+            tempfile.gettempdir(), "regressor" + str(np.random.randint(1000)) + ".model"
+        )
         regressor.save(file_name)
         try:
             regressor_load = NeuralNetworkRegressor.load(file_name)

--- a/test/algorithms/regressors/test_neural_network_regressor.py
+++ b/test/algorithms/regressors/test_neural_network_regressor.py
@@ -155,11 +155,10 @@ class TestNeuralNetworkRegressor(QiskitMachineLearningTestCase):
         original_predicts = regressor.predict(test_features)
 
         # save/load, change the quantum instance and check if predicted values are the same
-        file_name = os.path.join(
-            tempfile.gettempdir(), "regressor" + str(np.random.randint(1000)) + ".model"
-        )
-        regressor.save(file_name)
-        try:
+        with tempfile.TemporaryDirectory() as dir_name:
+            file_name = os.path.join(dir_name, "regressor.model")
+            regressor.save(file_name)
+
             regressor_load = NeuralNetworkRegressor.load(file_name)
             loaded_model_predicts = regressor_load.predict(test_features)
 
@@ -173,6 +172,3 @@ class TestNeuralNetworkRegressor(QiskitMachineLearningTestCase):
 
             with self.assertRaises(TypeError):
                 FakeModel.load(file_name)
-
-        finally:
-            os.remove(file_name)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Sometimes CI unit tests fail on access to a temp where a test model was saved. Likely this happens due to some concurrent test execution. This PR randomizes file names in the tests.


### Details and comments
Exception that may happen now:
```
test.algorithms.classifiers.test_neural_network_classifier.TestNeuralNetworkClassifier.test_save_load_2_circuit_qnn
-------------------------------------------------------------------------------------------------------------------

Captured traceback:
~~~~~~~~~~~~~~~~~~~
    Traceback (most recent call last):

      File "/home/runner/work/qiskit-machine-learning/qiskit-machine-learning/test/algorithms/classifiers/test_neural_network_classifier.py", line 320, in test_save_load
    classifier_load = NeuralNetworkClassifier.load(file_name)

      File "/home/runner/work/qiskit-machine-learning/qiskit-machine-learning/qiskit_machine_learning/algorithms/serializable_model.py", line 54, in load
    with open(file_name, "rb") as handler:

    FileNotFoundError: [Errno 2] No such file or directory: '/tmp/classifier.model'
```

