### PR TITLE
QuantumKernel unit test parameter bind fix

### DIFF
--- a/test/kernels/algorithms/test_qkernel_trainer.py
+++ b/test/kernels/algorithms/test_qkernel_trainer.py
@@ -39,11 +39,8 @@ class TestQuantumKernelTrainer(QiskitMachineLearningTestCase):
         # pylint: disable=no-member
         self.backend = qiskit.providers.aer.AerSimulator(method="statevector")
         data_block = ZZFeatureMap(2)
-        trainable_block = ZZFeatureMap(2)
+        trainable_block = ZZFeatureMap(2, parameter_prefix="θ")
         training_parameters = trainable_block.parameters
-
-        for i, training_parameter in enumerate(training_parameters):
-            training_parameter._name = f"θ[{i}]"
 
         self.feature_map = data_block.compose(trainable_block).compose(data_block)
         self.training_parameters = training_parameters

--- a/test/kernels/test_deprecated_qkernel_methods.py
+++ b/test/kernels/test_deprecated_qkernel_methods.py
@@ -35,10 +35,8 @@ class TestQuantumKernelTrainingParameters(QiskitMachineLearningTestCase):
 
         # Create an arbitrary 3-qubit feature map circuit
         circ1 = ZZFeatureMap(3)
-        circ2 = ZZFeatureMap(3)
+        circ2 = ZZFeatureMap(3, parameter_prefix="θ")
         user_params = circ2.parameters
-        for i, user_param in enumerate(user_params):
-            user_param._name = f"θ[{i}]"
 
         self.feature_map = circ1.compose(circ2).compose(circ1)
         self.user_parameters = user_params

--- a/test/kernels/test_qkernel.py
+++ b/test/kernels/test_qkernel.py
@@ -416,10 +416,8 @@ class TestQuantumKernelTrainingParameters(QiskitMachineLearningTestCase):
 
         # Create an arbitrary 3-qubit feature map circuit
         circ1 = ZZFeatureMap(3)
-        circ2 = ZZFeatureMap(3)
+        circ2 = ZZFeatureMap(3, parameter_prefix="θ")
         training_params = circ2.parameters
-        for i, training_param in enumerate(training_params):
-            training_param._name = f"θ[{i}]"
 
         self.feature_map = circ1.compose(circ2).compose(circ1)
         self.training_parameters = training_params


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The unit tests for the `QuantumKernel` and `QuantumKernelTrainer` were changing the names of feature map parameters by manually accessing and changing the private variable `parameter._name`. Although this changes the name of the variable, it does not change the actual instruction in the circuit. In this case, the unit tests still work (which probably means we should add more unit tests), but generally this can lead to unexpected behaviour.



### Details and comments
The code is fixed by changing parameters the intended way, i.e. setting the `parameter_prefix` when initialising the feature map.


