### PR TITLE
Load Aer dynamically in unit tests

### DIFF
--- a/test/algorithms/classifiers/test_neural_network_classifier.py
+++ b/test/algorithms/classifiers/test_neural_network_classifier.py
@@ -21,7 +21,7 @@ from test import QiskitMachineLearningTestCase
 import numpy as np
 import scipy
 from ddt import ddt, data, idata, unpack
-import qiskit
+
 from qiskit.algorithms.optimizers import COBYLA, L_BFGS_B, SPSA, Optimizer
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.library import RealAmplitudes, ZZFeatureMap
@@ -55,13 +55,16 @@ class TestNeuralNetworkClassifier(QiskitMachineLearningTestCase):
 
         # specify quantum instances
         algorithm_globals.random_seed = 12345
+        import importlib
+
+        aer = importlib.import_module("qiskit.providers.aer")
         self.sv_quantum_instance = QuantumInstance(
-            qiskit.providers.aer.Aer.get_backend("aer_simulator_statevector"),
+            aer.Aer.get_backend("aer_simulator_statevector"),
             seed_simulator=algorithm_globals.random_seed,
             seed_transpiler=algorithm_globals.random_seed,
         )
         self.qasm_quantum_instance = QuantumInstance(
-            qiskit.providers.aer.Aer.get_backend("aer_simulator"),
+            aer.Aer.get_backend("aer_simulator"),
             shots=100,
             seed_simulator=algorithm_globals.random_seed,
             seed_transpiler=algorithm_globals.random_seed,

--- a/test/algorithms/classifiers/test_vqc.py
+++ b/test/algorithms/classifiers/test_vqc.py
@@ -27,7 +27,6 @@ import scipy
 from sklearn.datasets import make_classification
 from sklearn.preprocessing import MinMaxScaler, OneHotEncoder
 
-import qiskit
 from qiskit import QuantumCircuit
 from qiskit.algorithms.optimizers import COBYLA, L_BFGS_B
 from qiskit.circuit.library import RealAmplitudes, ZZFeatureMap, ZFeatureMap
@@ -76,15 +75,17 @@ class TestVQC(QiskitMachineLearningTestCase):
         super().setUp()
         algorithm_globals.random_seed = 1111111
         self.num_classes_by_batch = []
+        import importlib
 
+        aer = importlib.import_module("qiskit.providers.aer")
         # Set-up the quantum instances.
         statevector = QuantumInstance(
-            qiskit.providers.aer.Aer.get_backend("aer_simulator_statevector"),
+            aer.Aer.get_backend("aer_simulator_statevector"),
             seed_simulator=algorithm_globals.random_seed,
             seed_transpiler=algorithm_globals.random_seed,
         )
         qasm = QuantumInstance(
-            qiskit.providers.aer.Aer.get_backend("aer_simulator"),
+            aer.Aer.get_backend("aer_simulator"),
             shots=100,
             seed_simulator=algorithm_globals.random_seed,
             seed_transpiler=algorithm_globals.random_seed,

--- a/test/algorithms/regressors/test_neural_network_regressor.py
+++ b/test/algorithms/regressors/test_neural_network_regressor.py
@@ -20,7 +20,7 @@ from test import QiskitMachineLearningTestCase
 
 import numpy as np
 from ddt import ddt, unpack, idata
-import qiskit
+
 from qiskit.algorithms.optimizers import COBYLA, L_BFGS_B, SPSA
 from qiskit.circuit import Parameter, QuantumCircuit
 from qiskit.circuit.library import ZZFeatureMap, RealAmplitudes
@@ -47,13 +47,16 @@ class TestNeuralNetworkRegressor(QiskitMachineLearningTestCase):
 
         # specify quantum instances
         algorithm_globals.random_seed = 12345
+        import importlib
+
+        aer = importlib.import_module("qiskit.providers.aer")
         self.sv_quantum_instance = QuantumInstance(
-            qiskit.providers.aer.Aer.get_backend("aer_simulator_statevector"),
+            aer.Aer.get_backend("aer_simulator_statevector"),
             seed_simulator=algorithm_globals.random_seed,
             seed_transpiler=algorithm_globals.random_seed,
         )
         self.qasm_quantum_instance = QuantumInstance(
-            qiskit.providers.aer.Aer.get_backend("aer_simulator"),
+            aer.Aer.get_backend("aer_simulator"),
             shots=100,
             seed_simulator=algorithm_globals.random_seed,
             seed_transpiler=algorithm_globals.random_seed,

--- a/test/algorithms/regressors/test_vqr.py
+++ b/test/algorithms/regressors/test_vqr.py
@@ -18,7 +18,6 @@ from test import QiskitMachineLearningTestCase
 import numpy as np
 from ddt import data, ddt
 
-import qiskit
 from qiskit.algorithms.optimizers import COBYLA, L_BFGS_B
 from qiskit.circuit import Parameter, QuantumCircuit
 from qiskit.utils import QuantumInstance, algorithm_globals, optionals
@@ -35,13 +34,16 @@ class TestVQR(QiskitMachineLearningTestCase):
 
         # specify quantum instances
         algorithm_globals.random_seed = 12345
+        import importlib
+
+        aer = importlib.import_module("qiskit.providers.aer")
         self.sv_quantum_instance = QuantumInstance(
-            qiskit.providers.aer.Aer.get_backend("aer_simulator_statevector"),
+            aer.Aer.get_backend("aer_simulator_statevector"),
             seed_simulator=algorithm_globals.random_seed,
             seed_transpiler=algorithm_globals.random_seed,
         )
         self.qasm_quantum_instance = QuantumInstance(
-            qiskit.providers.aer.Aer.get_backend("aer_simulator"),
+            aer.Aer.get_backend("aer_simulator"),
             shots=100,
             seed_simulator=algorithm_globals.random_seed,
             seed_transpiler=algorithm_globals.random_seed,

--- a/test/circuit/library/test_raw_feature_vector.py
+++ b/test/circuit/library/test_raw_feature_vector.py
@@ -96,8 +96,11 @@ class TestRawFeatureVector(QiskitMachineLearningTestCase):
 
         # specify quantum instance and random seed
         algorithm_globals.random_seed = 12345
+        import importlib
+
+        aer = importlib.import_module("qiskit.providers.aer")
         quantum_instance = QuantumInstance(
-            qiskit.providers.aer.Aer.get_backend("aer_simulator_statevector"),
+            aer.Aer.get_backend("aer_simulator_statevector"),
             seed_simulator=algorithm_globals.random_seed,
             seed_transpiler=algorithm_globals.random_seed,
         )

--- a/test/connectors/test_torch.py
+++ b/test/connectors/test_torch.py
@@ -14,7 +14,6 @@
 
 import unittest
 from abc import ABC, abstractmethod
-import qiskit
 from qiskit.utils import QuantumInstance, algorithm_globals, optionals
 import qiskit_machine_learning.optionals as _optionals
 
@@ -33,14 +32,17 @@ class TestTorch(ABC):
         """Base setup."""
         algorithm_globals.random_seed = 12345
         # specify quantum instances
+        import importlib
+
+        aer = importlib.import_module("qiskit.providers.aer")
         self._sv_quantum_instance = QuantumInstance(
-            qiskit.providers.aer.Aer.get_backend("aer_simulator_statevector"),
+            aer.Aer.get_backend("aer_simulator_statevector"),
             seed_simulator=algorithm_globals.random_seed,
             seed_transpiler=algorithm_globals.random_seed,
         )
         # pylint: disable=no-member
         self._qasm_quantum_instance = QuantumInstance(
-            qiskit.providers.aer.AerSimulator(),
+            aer.AerSimulator(),
             shots=100,
             seed_simulator=algorithm_globals.random_seed,
             seed_transpiler=algorithm_globals.random_seed,

--- a/test/neural_networks/test_circuit_qnn.py
+++ b/test/neural_networks/test_circuit_qnn.py
@@ -20,7 +20,6 @@ from ddt import ddt, data, idata, unpack
 
 import numpy as np
 
-import qiskit
 from qiskit.circuit import QuantumCircuit, Parameter
 from qiskit.circuit.library import RealAmplitudes, ZZFeatureMap
 from qiskit.utils import QuantumInstance, algorithm_globals, optionals
@@ -50,21 +49,25 @@ class TestCircuitQNN(QiskitMachineLearningTestCase):
     def setUp(self):
         super().setUp()
         algorithm_globals.random_seed = 12345
+        import importlib
+
+        aer = importlib.import_module("qiskit.providers.aer")
+
         # specify "run configuration"
         self.quantum_instance_sv = QuantumInstance(
-            qiskit.providers.aer.Aer.get_backend("aer_simulator_statevector"),
+            aer.Aer.get_backend("aer_simulator_statevector"),
             seed_simulator=algorithm_globals.random_seed,
             seed_transpiler=algorithm_globals.random_seed,
         )
         # pylint: disable=no-member
         self.quantum_instance_qasm = QuantumInstance(
-            qiskit.providers.aer.AerSimulator(),
+            aer.AerSimulator(),
             shots=100,
             seed_simulator=algorithm_globals.random_seed,
             seed_transpiler=algorithm_globals.random_seed,
         )
         self.quantum_instance_pm = QuantumInstance(
-            qiskit.providers.aer.AerSimulator(),
+            aer.AerSimulator(),
             shots=100,
             seed_simulator=algorithm_globals.random_seed,
             seed_transpiler=algorithm_globals.random_seed,

--- a/test/neural_networks/test_effective_dimension.py
+++ b/test/neural_networks/test_effective_dimension.py
@@ -18,7 +18,6 @@ from test import QiskitMachineLearningTestCase
 import numpy as np
 from ddt import ddt, data, unpack
 
-import qiskit
 from qiskit.circuit import QuantumCircuit
 from qiskit.circuit.library import ZFeatureMap, RealAmplitudes
 from qiskit.utils import QuantumInstance, algorithm_globals, optionals
@@ -41,8 +40,11 @@ class TestEffectiveDimension(QiskitMachineLearningTestCase):
         super().setUp()
 
         algorithm_globals.random_seed = 1234
+        import importlib
+
+        aer = importlib.import_module("qiskit.providers.aer")
         qi_sv = QuantumInstance(
-            qiskit.providers.aer.Aer.get_backend("aer_simulator_statevector"),
+            aer.Aer.get_backend("aer_simulator_statevector"),
             seed_simulator=algorithm_globals.random_seed,
             seed_transpiler=algorithm_globals.random_seed,
         )

--- a/test/neural_networks/test_opflow_qnn.py
+++ b/test/neural_networks/test_opflow_qnn.py
@@ -20,7 +20,7 @@ import unittest
 from ddt import ddt, data
 
 import numpy as np
-import qiskit
+
 from qiskit.circuit import Parameter, QuantumCircuit
 from qiskit.opflow import PauliExpectation, Gradient, StateFn, PauliSumOp, ListOp
 from qiskit.utils import QuantumInstance, algorithm_globals, optionals
@@ -41,15 +41,18 @@ class TestOpflowQNN(QiskitMachineLearningTestCase):
         super().setUp()
 
         algorithm_globals.random_seed = 12345
+        import importlib
+
+        aer = importlib.import_module("qiskit.providers.aer")
         # specify quantum instances
         self.sv_quantum_instance = QuantumInstance(
-            qiskit.providers.aer.Aer.get_backend("aer_simulator_statevector"),
+            aer.Aer.get_backend("aer_simulator_statevector"),
             seed_simulator=algorithm_globals.random_seed,
             seed_transpiler=algorithm_globals.random_seed,
         )
         # pylint: disable=no-member
         self.qasm_quantum_instance = QuantumInstance(
-            qiskit.providers.aer.AerSimulator(),
+            aer.AerSimulator(),
             shots=100,
             seed_simulator=algorithm_globals.random_seed,
             seed_transpiler=algorithm_globals.random_seed,

--- a/test/neural_networks/test_two_layer_qnn.py
+++ b/test/neural_networks/test_two_layer_qnn.py
@@ -17,7 +17,7 @@ import unittest
 from test import QiskitMachineLearningTestCase
 
 import numpy as np
-import qiskit
+
 from ddt import ddt, data
 from qiskit import QuantumCircuit
 from qiskit.circuit.library import RealAmplitudes, ZFeatureMap, ZZFeatureMap
@@ -35,9 +35,12 @@ class TestTwoLayerQNN(QiskitMachineLearningTestCase):
     def setUp(self):
         super().setUp()
         algorithm_globals.random_seed = 12345
+        import importlib
+
+        aer = importlib.import_module("qiskit.providers.aer")
         # specify "run configuration"
         self.quantum_instance = QuantumInstance(
-            qiskit.providers.aer.Aer.get_backend("aer_simulator_statevector"),
+            aer.Aer.get_backend("aer_simulator_statevector"),
             seed_simulator=algorithm_globals.random_seed,
             seed_transpiler=algorithm_globals.random_seed,
         )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Aer is in the process of migrating out of namespaces.
In the meantime, `from qiskit import Aer` emits a deprecation asking to use qiskit_aer which is not ready yet.
Using `qiskit.providers.aer` works fine but it is giving pylint errors when statically loading.

Until qiskit-aer has its own root package qiskit_aer, I am importing Aer dynamically under unit tests to avoid pylint errors.


### Details and comments


