### PR TITLE
Remove cross entropy sigmoid loss as deprecated

### DIFF
--- a/qiskit_machine_learning/algorithms/classifiers/neural_network_classifier.py
+++ b/qiskit_machine_learning/algorithms/classifiers/neural_network_classifier.py
@@ -66,7 +66,7 @@ class NeuralNetworkClassifier(TrainableModel, ClassifierMixin):
                 function is applied to the index and weighted with the corresponding probability.
             loss: A target loss function to be used in training. Default is `squared_error`,
                 i.e. L2 loss. Can be given either as a string for 'absolute_error' (i.e. L1 Loss),
-                'squared_error', 'cross_entropy', 'cross_entropy_sigmoid', or as a loss function
+                'squared_error', 'cross_entropy', or as a loss function
                 implementing the Loss interface.
             one_hot: Determines in the case of a multi-dimensional result of the
                 neural_network how to interpret the result. If True it is interpreted as a single

--- a/qiskit_machine_learning/algorithms/trainable_model.py
+++ b/qiskit_machine_learning/algorithms/trainable_model.py
@@ -26,18 +26,15 @@ from qiskit_machine_learning.utils.loss_functions import (
     L1Loss,
     L2Loss,
     CrossEntropyLoss,
-    CrossEntropySigmoidLoss,
 )
 
 from .objective_functions import ObjectiveFunction
 from .serializable_model import SerializableModelMixin
-from ..deprecation import deprecate_values
 
 
 class TrainableModel(SerializableModelMixin):
     """Base class for ML model. This class defines Scikit-Learn like interface to implement."""
 
-    @deprecate_values("0.4.0", {"loss": {"cross_entropy_sigmoid": "<unsupported>"}})
     def __init__(
         self,
         neural_network: NeuralNetwork,
@@ -61,7 +58,7 @@ class TrainableModel(SerializableModelMixin):
                 function is applied to the index and weighted with the corresponding probability.
             loss: A target loss function to be used in training. Default is `squared_error`,
                 i.e. L2 loss. Can be given either as a string for 'absolute_error' (i.e. L1 Loss),
-                'squared_error', 'cross_entropy', 'cross_entropy_sigmoid', or as a loss function
+                'squared_error', 'cross_entropy', or as a loss function
                 implementing the Loss interface.
             optimizer: An instance of an optimizer to be used in training. When `None` defaults to SLSQP.
             warm_start: Use weights from previous fit to start next fit.
@@ -87,8 +84,6 @@ class TrainableModel(SerializableModelMixin):
                 self._loss = L2Loss()
             elif loss == "cross_entropy":
                 self._loss = CrossEntropyLoss()
-            elif loss == "cross_entropy_sigmoid":
-                self._loss = CrossEntropySigmoidLoss()
             else:
                 raise QiskitMachineLearningError(f"Unknown loss {loss}!")
 

--- a/qiskit_machine_learning/utils/loss_functions/__init__.py
+++ b/qiskit_machine_learning/utils/loss_functions/__init__.py
@@ -38,7 +38,6 @@ Loss Functions
    L1Loss
    L2Loss
    CrossEntropyLoss
-   CrossEntropySigmoidLoss
    SVCLoss
 """
 
@@ -47,7 +46,6 @@ from .loss_functions import (
     L1Loss,
     L2Loss,
     CrossEntropyLoss,
-    CrossEntropySigmoidLoss,
 )
 
 from .kernel_loss_functions import KernelLoss, SVCLoss
@@ -58,6 +56,5 @@ __all__ = [
     "L1Loss",
     "L2Loss",
     "CrossEntropyLoss",
-    "CrossEntropySigmoidLoss",
     "SVCLoss",
 ]

--- a/qiskit_machine_learning/utils/loss_functions/loss_functions.py
+++ b/qiskit_machine_learning/utils/loss_functions/loss_functions.py
@@ -16,7 +16,6 @@ from abc import ABC, abstractmethod
 
 import numpy as np
 
-from ...deprecation import warn_deprecated, DeprecatedType
 from ...exceptions import QiskitMachineLearningError
 
 
@@ -176,31 +175,3 @@ class CrossEntropyLoss(Loss):
         grad = np.einsum("ij,i->ij", predict, np.sum(target, axis=1)) - target
 
         return grad
-
-
-class CrossEntropySigmoidLoss(Loss):
-    """
-    This class computes the cross entropy sigmoid loss and should be used for binary classification.
-    """
-
-    def __init__(self) -> None:
-        warn_deprecated("0.4.0", DeprecatedType.CLASS, "CrossEntropySigmoidLoss")
-        super().__init__()
-
-    def evaluate(self, predict: np.ndarray, target: np.ndarray) -> np.ndarray:
-        self._validate_shapes(predict, target)
-
-        if len(set(target)) != 2:
-            raise QiskitMachineLearningError(
-                "Sigmoid Cross Entropy is used for binary classification!"
-            )
-
-        x = CrossEntropyLoss()
-        return 1.0 / (1.0 + np.exp(-x.evaluate(predict, target)))
-
-    def gradient(self, predict: np.ndarray, target: np.ndarray) -> np.ndarray:
-        self._validate_shapes(predict, target)
-
-        return target * (1.0 / (1.0 + np.exp(-predict)) - 1) + (1 - target) * (
-            1.0 / (1.0 + np.exp(-predict))
-        )


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Remove `CrossEntropySigmoidLoss` as deprecated in the version 0.4.

