### PR TITLE
`qiskit.utils.deprecate_function` has no `category` kwarg

### DIFF
--- a/qiskit_machine_learning/neural_networks/circuit_qnn.py
+++ b/qiskit_machine_learning/neural_networks/circuit_qnn.py
@@ -54,7 +54,6 @@ class CircuitQNN(SamplingNeuralNetwork):
         "This class will be deprecated in a future release and subsequently "
         "removed after that.",
         stacklevel=3,
-        category=PendingDeprecationWarning,
     )
     def __init__(
         self,


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
`qiskit.utils.deprecate_function` has no `category` kwarg leading to an error at the user end
```
TypeError: deprecate_function() got an unexpected keyword argument 'category'
```


### Details and comments


