### PR TITLE
Fix code block in getting started page

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -95,11 +95,11 @@ See :ref:`optional_installs` for more information.
 Optional installs
 =================
 
-* **PyTorch**, may be installed either using command `pip install 'qiskit-machine-learning[torch]'` to install the
+* **PyTorch**, may be installed either using command ``pip install 'qiskit-machine-learning[torch]'`` to install the
   package or refer to PyTorch `getting started <https://pytorch.org/get-started/locally/>`__. When PyTorch
   is installed, the `TorchConnector` facilitates its use of quantum computed networks.
 
-* **Sparse**, may be installed using command `pip install 'qiskit-machine-learning[sparse]'` to install the
+* **Sparse**, may be installed using command ``pip install 'qiskit-machine-learning[sparse]'`` to install the
   package. Sparse being installed will enable the usage of sparse arrays/tensors.
 
 ----


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This PR fixes code block typo in the getting started page

### Details and comments

Currently, we see `pip install 'qiskit-machine-learning[torch]` and `pip install 'qiskit-machine-learning[sparse]'` in italics and not in code block.


![image](https://user-images.githubusercontent.com/11485594/206473983-96a41a1e-f75c-4c15-9ada-6611bbfff9b0.png)

