### PR TITLE
Add shot noise emulation to FidelityStatevectorKernel

### DIFF
--- a/qiskit_machine_learning/kernels/fidelity_statevector_kernel.py
+++ b/qiskit_machine_learning/kernels/fidelity_statevector_kernel.py
@@ -69,7 +69,7 @@ class FidelityStatevectorKernel(BaseKernel):
         cache_size: int | None = None,
         auto_clear_cache: bool = True,
         shots: int | None = None,
-        enforce_psd: bool = False,
+        enforce_psd: bool = True,
     ) -> None:
         """
         Args:
@@ -88,7 +88,7 @@ class FidelityStatevectorKernel(BaseKernel):
                 mean is taken of samples drawn from a binomial distribution with probability equal
                 to the exact fidelity.
             enforce_psd: Project to the closest positive semidefinite matrix if ``x = y``.
-                This is only required if the number of shots is specified.
+                This is only used when number of shots given is not ``None``.
         """
         super().__init__(feature_map=feature_map)
 

--- a/qiskit_machine_learning/kernels/fidelity_statevector_kernel.py
+++ b/qiskit_machine_learning/kernels/fidelity_statevector_kernel.py
@@ -51,8 +51,8 @@ class FidelityStatevectorKernel(BaseKernel):
     compute-uncompute method. I.e., the fidelity is given by the probability of measuring
     :math:`0` after preparing the state :math:`U(x)^\dagger U(y) | 0 \rangle`.
 
-    With the addition of shot noise, the kernel matrix may no longer be positive semi-definite
-    (PSD). With ``enforce_psd`` set to ``True`` this condition is enforced.
+    With the addition of shot noise, the kernel matrix may no longer be positive semi-definite. With
+    ``enforce_psd`` set to ``True`` this condition is enforced.
 
     **References:**
     [1] Havlíček, V., Córcoles, A. D., Temme, K., Harrow, A. W., Kandala,

--- a/releasenotes/notes/add-fidelity-statevector-kernel-4b9ac887169daf61.yaml
+++ b/releasenotes/notes/add-fidelity-statevector-kernel-4b9ac887169daf61.yaml
@@ -17,6 +17,9 @@ features:
     Otherwise, the mean is taken of samples drawn from a binomial distribution with probability
     equal to the exact fidelity.
 
+    With the addition of shot noise, the kernel matrix may no longer be positive semi-definite
+    (PSD). With ``enforce_psd`` set to ``True`` this condition is enforced.
+
     An example of using this class is as follows:
 
     .. code-block:: python
@@ -43,6 +46,7 @@ features:
             cache_size=len(labels),
             auto_clear_cache=True,
             shots=1000,
+            enforce_psd=True,
         )
         svc = SVC(kernel=kernel.evaluate)
         svc.fit(features, labels)

--- a/releasenotes/notes/add-fidelity-statevector-kernel-4b9ac887169daf61.yaml
+++ b/releasenotes/notes/add-fidelity-statevector-kernel-4b9ac887169daf61.yaml
@@ -5,13 +5,17 @@ features:
     optimized to use only statevector-implemented feature maps. Therefore, computational complexity
     is reduced from :math:`O(N^2)` to :math:`O(N)`.
 
-    Computed statevector arrays are also cached to further increase efficiency unless. This cache is
+    Computed statevector arrays are also cached to further increase efficiency. This cache is
     cleared when the ``evaluate`` method is called, unless ``auto_clear_cache`` is ``False``. The
     cache is unbounded by default, but its size can be set by the user, i.e., limited to the number
     of samples in the worst case.
 
     By default the Terra reference ``Statevector`` is used, however, the type can be specified via
     the ``statevector_type`` argument.
+
+    Shot noise emulation can also be added. If ``shots`` is ``None``, the exact fidelity is used.
+    Otherwise, the mean is taken of samples drawn from a binomial distribution with probability
+    equal to the exact fidelity.
 
     An example of using this class is as follows:
 
@@ -38,6 +42,7 @@ features:
             statevector_type=Statevector,
             cache_size=len(labels),
             auto_clear_cache=True,
+            shots=1000,
         )
         svc = SVC(kernel=kernel.evaluate)
         svc.fit(features, labels)

--- a/test/kernels/test_fidelity_statevector_kernel.py
+++ b/test/kernels/test_fidelity_statevector_kernel.py
@@ -101,6 +101,15 @@ class TestStatevectorKernel(QiskitMachineLearningTestCase):
 
         self.assertGreaterEqual(score, 0.5)
 
+    def test_with_shot_noise(self):
+        """Test statevector kernel with shot noise emulation."""
+        features = algorithm_globals.random.random((3, 2)) - 0.5
+        kernel = FidelityStatevectorKernel(feature_map=self.feature_map, shots=10)
+        kernel_train = kernel.evaluate(x_vec=features)
+        np.testing.assert_array_almost_equal(
+            kernel_train, [[1, 0.9, 0.9], [0.4, 1, 1], [0.7, 0.8, 1]]
+        )
+
     @unittest.skipUnless(optionals.HAS_AER, "qiskit-aer is required to run this test")
     def test_aer_statevector(self):
         """Test statevector kernel when using AerStatevector type statevectors."""

--- a/test/kernels/test_fidelity_statevector_kernel.py
+++ b/test/kernels/test_fidelity_statevector_kernel.py
@@ -104,11 +104,32 @@ class TestStatevectorKernel(QiskitMachineLearningTestCase):
     def test_with_shot_noise(self):
         """Test statevector kernel with shot noise emulation."""
         features = algorithm_globals.random.random((3, 2)) - 0.5
-        kernel = FidelityStatevectorKernel(feature_map=self.feature_map, shots=10)
+        kernel = FidelityStatevectorKernel(
+            feature_map=self.feature_map, shots=10, enforce_psd=False
+        )
         kernel_train = kernel.evaluate(x_vec=features)
         np.testing.assert_array_almost_equal(
             kernel_train, [[1, 0.9, 0.9], [0.4, 1, 1], [0.7, 0.8, 1]]
         )
+
+    def test_enforce_psd(self):
+        """Test enforce_psd"""
+
+        with self.subTest("No PSD enforcement"):
+            kernel = FidelityStatevectorKernel(enforce_psd=False)
+            kernel._compute_kernel_entry = lambda *args, **kwargs: -1
+            matrix = kernel.evaluate(self.sample_train)
+            eigen_values = np.linalg.eigvals(matrix)
+            # there's a negative eigenvalue
+            self.assertFalse(np.all(np.greater_equal(eigen_values, -1e-10)))
+
+        with self.subTest("PSD enforced"):
+            kernel = FidelityStatevectorKernel(enforce_psd=True)
+            kernel._compute_kernel_element = lambda *args, **kwargs: -1
+            matrix = kernel.evaluate(self.sample_train)
+            eigen_values = np.linalg.eigvals(matrix)
+            # all eigenvalues are non-negative with some tolerance
+            self.assertTrue(np.all(np.greater_equal(eigen_values, -1e-10)))
 
     @unittest.skipUnless(optionals.HAS_AER, "qiskit-aer is required to run this test")
     def test_aer_statevector(self):


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Adds shot noise emulation to `FidelityStatevectorKernel`. Closes #557.

### Details and comments

A `shots` argument is added. If `shots` is `None`, the exact fidelity is used. Otherwise, the mean is taken of samples drawn from a binomial distribution with probability equal to the exact fidelity.

