### PR TITLE
Fix SamplerQNN when no input parameters and no weights are set in the quantum circuit

### DIFF
--- a/qiskit_machine_learning/neural_networks/neural_network.py
+++ b/qiskit_machine_learning/neural_networks/neural_network.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2020, 2022.
+# (C) Copyright IBM 2020, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -164,7 +164,8 @@ class NeuralNetwork(ABC):
                 num_samples = 1
                 parameters = np.broadcast_to(weights, (num_samples, len(weights)))
             else:
-                return None, None
+                # no input, no weights, just execute circuit once
+                return np.asarray([]), 1
         return parameters, num_samples
 
     def _validate_weights(

--- a/releasenotes/notes/fix-sampler-qnn-no-data.yaml
+++ b/releasenotes/notes/fix-sampler-qnn-no-data.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    :class:`~qiskit_machine_learning.neural_networks.SamplerQNN` can now correctly handle quantum
+    circuits without both input parameters and weights. If such a circuit is passed to the QNN then
+    this circuit executed once in the forward pass and backward returns ``None`` for both gradients.

--- a/test/neural_networks/test_sampler_qnn.py
+++ b/test/neural_networks/test_sampler_qnn.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2022.
+# (C) Copyright IBM 2022, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -11,6 +11,7 @@
 # that they have been altered from the originals.
 
 """Test Sampler QNN with Terra primitives."""
+from __future__ import annotations
 
 from test import QiskitMachineLearningTestCase
 
@@ -131,7 +132,11 @@ class TestSamplerQNN(QiskitMachineLearningTestCase):
         return qnn
 
     def _verify_qnn(
-        self, qnn: SamplerQNN, batch_size: int, input_data: np.ndarray, weights: np.ndarray
+        self,
+        qnn: SamplerQNN,
+        batch_size: int,
+        input_data: np.ndarray | None,
+        weights: np.ndarray | None,
     ) -> None:
         """
         Verifies that a QNN functions correctly
@@ -162,7 +167,7 @@ class TestSamplerQNN(QiskitMachineLearningTestCase):
                 )
                 self.assertTrue(isinstance(weights_grad, self.array_type[qnn.sparse]))
             else:
-                # verify that input gradients are None if turned off
+                # verify that weight gradients are None if no weights
                 self.assertIsNone(weights_grad)
 
         else:
@@ -173,6 +178,9 @@ class TestSamplerQNN(QiskitMachineLearningTestCase):
                     weights_grad.shape, (batch_size, *qnn.output_shape, qnn.num_weights)
                 )
                 self.assertTrue(isinstance(weights_grad, self.array_type[qnn.sparse]))
+            else:
+                # verify that weight gradients are None if no weights
+                self.assertIsNone(weights_grad)
 
     @unittest.skipIf(not _optionals.HAS_SPARSE, "Sparse not available.")
     @idata(itertools.product(SPARSE, SAMPLERS, INTERPRET_TYPES, BATCH_SIZES, INPUT_GRADS))
@@ -294,3 +302,43 @@ class TestSamplerQNN(QiskitMachineLearningTestCase):
             self.assertFalse(sampler_qnn.input_gradients)
             sampler_qnn.input_gradients = True
             self.assertTrue(sampler_qnn.input_gradients)
+
+    def test_no_parameters(self):
+        """Test when some parameters are not set."""
+        params = [Parameter("p0"), Parameter("p1")]
+        qc = QuantumCircuit(1)
+        qc.h(0)
+        qc.ry(params[0], 0)
+        qc.rx(params[1], 0)
+
+        with self.subTest("no inputs"):
+            sampler_qnn = SamplerQNN(
+                circuit=qc,
+                weight_params=params,
+            )
+            self._verify_qnn(sampler_qnn, 1, input_data=None, weights=[1, 2])
+
+            sampler_qnn.input_gradients = True
+            self._verify_qnn(sampler_qnn, 1, input_data=None, weights=[1, 2])
+
+        with self.subTest("no weights"):
+            sampler_qnn = SamplerQNN(
+                circuit=qc,
+                input_params=params,
+            )
+            self._verify_qnn(sampler_qnn, 1, input_data=[1, 2], weights=None)
+
+            sampler_qnn.input_gradients = True
+            self._verify_qnn(sampler_qnn, 1, input_data=[1, 2], weights=None)
+
+        with self.subTest("no parameters"):
+            qc = qc.bind_parameters([1, 2])
+
+            sampler_qnn = SamplerQNN(
+                circuit=qc,
+            )
+
+            self._verify_qnn(sampler_qnn, 1, input_data=None, weights=None)
+
+            sampler_qnn.input_gradients = True
+            self._verify_qnn(sampler_qnn, 1, input_data=None, weights=None)


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
`SamplerQNN` can now correctly handle quantum circuits without both input parameters and weights. If such a circuit is passed to the QNN then this circuit executed once in the forward pass and backward returns ``None`` for both gradients.


### Details and comments
Changes:
- Some fixes in SamplerQNN to allow circuits without inputs and/or weights.
- Some tweaks in the backward pass of EstimatorQNN to make it aligned with SamplerQNN.
- Removed unnecessary normalization in SamplerQNN.
- Some other minor tweaks in the QNNs.


