### PR TITLE
Fixing Typo on Line 106

### DIFF
--- a/docs/tutorials/02_neural_network_classifier_and_regressor.ipynb
+++ b/docs/tutorials/02_neural_network_classifier_and_regressor.ipynb
@@ -103,7 +103,7 @@
    "id": "religious-history",
    "metadata": {},
    "source": [
-    "### Classification with the an `EstimatorQNN`\n",
+    "### Classification with an `EstimatorQNN`\n",
     "\n",
     "First we show how an `EstimatorQNN` can be used for classification within a `NeuralNetworkClassifier`. In this context, the `EstimatorQNN` is expected to return one-dimensional output in $[-1, +1]$. This only works for binary classification and we assign the two classes to $\\{-1, +1\\}$."
    ]


### PR DESCRIPTION
I am part of the Qiskit German translation team and noticed the typo here: "Classification with the an `EstimatorQNN`" This needs to be changed as follows "Classification with an `EstimatorQNN`".

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


