### PR TITLE
Fix release notes

### DIFF
--- a/releasenotes/notes/remove-cross-entropy-sigmoid-caa9e794c20e2867.yaml
+++ b/releasenotes/notes/remove-cross-entropy-sigmoid-caa9e794c20e2867.yaml
@@ -1,4 +1,4 @@
 ---
-deprecations:
+upgrade:
   - |
     The previously deprecated ``CrossEntropySigmoidLoss`` loss function has been removed.

--- a/releasenotes/notes/remove-datasets-495a57011b14ccd7.yaml
+++ b/releasenotes/notes/remove-datasets-495a57011b14ccd7.yaml
@@ -1,5 +1,5 @@
 ---
-deprecations:
+upgrade:
   - |
     The previously deprecated datasets have been removed: ``breast_cancer``, ``digits``,
     ``gaussian``, ``iris``, ``wine``.

--- a/releasenotes/notes/remove-qsvc-qsvr-positional-arguments-36394f2da1a4ae17.yaml
+++ b/releasenotes/notes/remove-qsvc-qsvr-positional-arguments-36394f2da1a4ae17.yaml
@@ -1,5 +1,5 @@
 ---
-deprecations:
+upgrade:
   - |
     Positional arguments in :class:`~qiskit_machine_learning.algorithms.QSVC` and
     :class:`~qiskit_machine_learning.algorithms.QSVR` were deprecated as of version 0.3. Support of


### PR DESCRIPTION
These release notes are for removal of deprecated features where the category should be upgrade since if a user had still been using the prior deprecated code they need to upgrade their code now to not do so.