### PR TITLE
Add jupyter as requirements to testenv:gettext in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -88,6 +88,7 @@ deps =
   sparse
   torchvision<0.10.0
   sphinx-intl
+  jupyter
 commands =
   pip install -e .
   sphinx-build -W -T --keep-going -b gettext docs/ docs/_build/gettext {posargs}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR adds `jupyter` as a dependency to the `[testenv:gettext]` section of `tox.ini`. The reason is that `ipykernel` is not available when translatable string are being built. 


