### PR TITLE
Docs, typehints and thumbnail

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,7 +110,9 @@ html_css_files = ["style.css", "custom.css", "gallery.css"]
 nbsphinx_timeout = 360
 nbsphinx_execute = os.getenv("QISKIT_DOCS_BUILD_TUTORIALS", "never")
 nbsphinx_widgets_path = ""
-nbsphinx_thumbnails = {}
+nbsphinx_thumbnails = {
+    "**": "_static/no_image.png",
+}
 
 spelling_word_list_filename = "../.pylintdict"
 spelling_filters = ["lowercase_filter.LowercaseFilter"]
@@ -125,6 +127,12 @@ autosummary_generate_overwrite = False
 # -----------------------------------------------------------------------------
 # Autodoc
 # -----------------------------------------------------------------------------
+# Move type hints from signatures to the parameter descriptions (except in overload cases, where
+# that's not possible).
+autodoc_typehints = "description"
+# Only add type hints from signature to description body if the parameter has documentation.  The
+# return type is always added to the description (if in the signature).
+autodoc_typehints_description_target = "documented_params"
 
 autodoc_default_options = {
     "inherited-members": None,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,7 +97,6 @@ extensions = [
     "sphinx.ext.extlinks",
     "sphinx_design",
     "jupyter_sphinx",
-    "sphinx_autodoc_typehints",
     "reno.sphinxext",
     "sphinx.ext.doctest",
     "nbsphinx",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,10 +7,9 @@ pylatexenc>=1.4
 stestr>=2.0.0
 ddt>=1.2.0,!=1.4.0
 reno>=3.4.0
-Sphinx>=1.8.3,!=3.1.0,!=5.2.0,!=5.2.0.post0
+Sphinx>=5.0
 sphinx-design>=0.2.0
 sphinx-gallery
-sphinx-autodoc-typehints<1.14.0
 sphinxcontrib-spelling
 jupyter-sphinx
 discover


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

See Qiskit/qiskit-nature#1109 for more detail.

Only the first two items, as below, are needed here. The 3rd, the tox.ini change, has already been done here.

* Removes dependency on sphinx-autodoc-typehints 
* Adds default thumbnail config as that changed in nbsphinx 0.9

Note: all the notebooks currently have a specific thumbnail, but since the default mechanism has changed, in case new content gets added that needs a default, the config has been updated.

### Details and comments


