### PR TITLE
Fix complex kernel matrix entries for FidelityStatevectorKernel

### DIFF
--- a/qiskit_machine_learning/kernels/base_kernel.py
+++ b/qiskit_machine_learning/kernels/base_kernel.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2022.
+# (C) Copyright IBM 2022, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory
@@ -136,18 +136,18 @@ class BaseKernel(ABC):
 
         return x_vec, y_vec
 
-    # pylint: disable=invalid-name
     def _make_psd(self, kernel_matrix: np.ndarray) -> np.ndarray:
         r"""
-        Find the closest positive semi-definite approximation to symmetric kernel matrix.
+        Find the closest positive semi-definite approximation to a symmetric kernel matrix.
         The (symmetric) matrix should always be positive semi-definite by construction,
         but this can be violated in case of noise, such as sampling noise.
 
         Args:
-            kernel_matrix: symmetric 2D array of the kernel entries
+            kernel_matrix: Symmetric 2D array of the kernel entries.
 
         Returns:
-            the closest positive semi-definite matrix.
+            The closest positive semi-definite matrix.
         """
-        d, u = np.linalg.eig(kernel_matrix)
-        return u @ np.diag(np.maximum(0, d)) @ u.transpose()
+        w, v = np.linalg.eig(kernel_matrix)
+        m = v @ np.diag(np.maximum(0, w)) @ v.transpose()
+        return m.real

--- a/qiskit_machine_learning/kernels/fidelity_quantum_kernel.py
+++ b/qiskit_machine_learning/kernels/fidelity_quantum_kernel.py
@@ -13,6 +13,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import List, Tuple
 
 import numpy as np
@@ -114,9 +115,6 @@ class FidelityQuantumKernel(BaseKernel):
         if is_symmetric and self._enforce_psd:
             kernel_matrix = self._make_psd(kernel_matrix)
 
-        # due to truncation and rounding errors we may get complex numbers
-        kernel_matrix = np.real(kernel_matrix)
-
         return kernel_matrix
 
     def _get_parameterization(
@@ -202,7 +200,9 @@ class FidelityQuantumKernel(BaseKernel):
 
         return kernel_matrix
 
-    def _get_kernel_entries(self, left_parameters: np.ndarray, right_parameters: np.ndarray):
+    def _get_kernel_entries(
+        self, left_parameters: np.ndarray, right_parameters: np.ndarray
+    ) -> Sequence[float]:
         """
         Gets kernel entries by executing the underlying fidelity instance and getting the results
         back from the async job.
@@ -215,7 +215,7 @@ class FidelityQuantumKernel(BaseKernel):
                 left_parameters,
                 right_parameters,
             )
-            kernel_entries = np.real(job.result().fidelities)
+            kernel_entries = job.result().fidelities
         else:
             # trivial case, only identical samples
             kernel_entries = []

--- a/qiskit_machine_learning/kernels/fidelity_statevector_kernel.py
+++ b/qiskit_machine_learning/kernels/fidelity_statevector_kernel.py
@@ -129,8 +129,8 @@ class FidelityStatevectorKernel(BaseKernel):
                     continue
                 kernel_matrix[i, j] = self._compute_kernel_entry(x, y)
 
-        if self._shots is not None and self._enforce_psd and is_symmetric:
-            kernel_matrix = self._make_psd(kernel_matrix)
+        if self._enforce_psd and is_symmetric and self._shots is not None:
+            kernel_matrix = self._make_psd(kernel_matrix).real
 
         return kernel_matrix
 

--- a/qiskit_machine_learning/kernels/fidelity_statevector_kernel.py
+++ b/qiskit_machine_learning/kernels/fidelity_statevector_kernel.py
@@ -130,7 +130,7 @@ class FidelityStatevectorKernel(BaseKernel):
                 kernel_matrix[i, j] = self._compute_kernel_entry(x, y)
 
         if self._enforce_psd and is_symmetric and self._shots is not None:
-            kernel_matrix = self._make_psd(kernel_matrix).real
+            kernel_matrix = self._make_psd(kernel_matrix)
 
         return kernel_matrix
 

--- a/releasenotes/notes/fix-complex-kernel-99b0c19dbf1a4717.yaml
+++ b/releasenotes/notes/fix-complex-kernel-99b0c19dbf1a4717.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes a bug in :class:`~qiskit_machine_learning.kernels.FidelityStatevectorKernel` where kernel
+    entries could potentially have nonzero complex components due to truncation and rounding
+    errors when enforcing a PSD matrix.

--- a/test/kernels/test_fidelity_statevector_kernel.py
+++ b/test/kernels/test_fidelity_statevector_kernel.py
@@ -119,17 +119,17 @@ class TestStatevectorKernel(QiskitMachineLearningTestCase):
             kernel = FidelityStatevectorKernel(enforce_psd=False, shots=1)
             kernel._add_shot_noise = lambda *args, **kwargs: -1
             matrix = kernel.evaluate(self.sample_train)
-            eigen_values = np.linalg.eigvals(matrix)
+            w = np.linalg.eigvals(matrix)
             # there's a negative eigenvalue
-            self.assertFalse(np.all(np.greater_equal(eigen_values, -1e-10)))
+            self.assertFalse(np.all(np.greater_equal(w, -1e-10)))
 
         with self.subTest("PSD enforced"):
             kernel = FidelityStatevectorKernel(enforce_psd=True, shots=1)
             kernel._add_shot_noise = lambda *args, **kwargs: -1
             matrix = kernel.evaluate(self.sample_train)
-            eigen_values = np.linalg.eigvals(matrix)
+            w = np.linalg.eigvals(matrix)
             # all eigenvalues are non-negative with some tolerance
-            self.assertTrue(np.all(np.greater_equal(eigen_values, -1e-10)))
+            self.assertTrue(np.all(np.greater_equal(w, -1e-10)))
 
     @unittest.skipUnless(optionals.HAS_AER, "qiskit-aer is required to run this test")
     def test_aer_statevector(self):

--- a/test/kernels/test_fidelity_statevector_kernel.py
+++ b/test/kernels/test_fidelity_statevector_kernel.py
@@ -133,7 +133,7 @@ class TestStatevectorKernel(QiskitMachineLearningTestCase):
 
         with self.subTest("Test kernel matrix is real-valued."):
             kernel = FidelityStatevectorKernel(enforce_psd=True, shots=1)
-            kernel._make_psd = lambda *args, **kwargs: np.asarray([1j,])
+            kernel._make_psd = lambda *args, **kwargs: np.asarray([1j])
             matrix = kernel.evaluate(self.sample_train)
             self.assertTrue(np.issubdtype(matrix.dtype, float))
 

--- a/test/kernels/test_fidelity_statevector_kernel.py
+++ b/test/kernels/test_fidelity_statevector_kernel.py
@@ -116,20 +116,26 @@ class TestStatevectorKernel(QiskitMachineLearningTestCase):
         """Test enforce_psd"""
 
         with self.subTest("No PSD enforcement"):
-            kernel = FidelityStatevectorKernel(enforce_psd=False)
-            kernel._compute_kernel_entry = lambda *args, **kwargs: -1
+            kernel = FidelityStatevectorKernel(enforce_psd=False, shots=1)
+            kernel._add_shot_noise = lambda *args, **kwargs: -1
             matrix = kernel.evaluate(self.sample_train)
             eigen_values = np.linalg.eigvals(matrix)
             # there's a negative eigenvalue
             self.assertFalse(np.all(np.greater_equal(eigen_values, -1e-10)))
 
         with self.subTest("PSD enforced"):
-            kernel = FidelityStatevectorKernel(enforce_psd=True)
-            kernel._compute_kernel_element = lambda *args, **kwargs: -1
+            kernel = FidelityStatevectorKernel(enforce_psd=True, shots=1)
+            kernel._add_shot_noise = lambda *args, **kwargs: -1
             matrix = kernel.evaluate(self.sample_train)
             eigen_values = np.linalg.eigvals(matrix)
             # all eigenvalues are non-negative with some tolerance
             self.assertTrue(np.all(np.greater_equal(eigen_values, -1e-10)))
+
+        with self.subTest("Test kernel matrix is real-valued."):
+            kernel = FidelityStatevectorKernel(enforce_psd=True, shots=1)
+            kernel._make_psd = lambda *args, **kwargs: np.asarray([1j,])
+            matrix = kernel.evaluate(self.sample_train)
+            self.assertTrue(np.issubdtype(matrix.dtype, float))
 
     @unittest.skipUnless(optionals.HAS_AER, "qiskit-aer is required to run this test")
     def test_aer_statevector(self):

--- a/test/kernels/test_fidelity_statevector_kernel.py
+++ b/test/kernels/test_fidelity_statevector_kernel.py
@@ -131,12 +131,6 @@ class TestStatevectorKernel(QiskitMachineLearningTestCase):
             # all eigenvalues are non-negative with some tolerance
             self.assertTrue(np.all(np.greater_equal(eigen_values, -1e-10)))
 
-        with self.subTest("Test kernel matrix is real-valued."):
-            kernel = FidelityStatevectorKernel(enforce_psd=True, shots=1)
-            kernel._make_psd = lambda *args, **kwargs: np.asarray([1j])
-            matrix = kernel.evaluate(self.sample_train)
-            self.assertTrue(np.issubdtype(matrix.dtype, float))
-
     @unittest.skipUnless(optionals.HAS_AER, "qiskit-aer is required to run this test")
     def test_aer_statevector(self):
         """Test statevector kernel when using AerStatevector type statevectors."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Takes the real part of the kernel array when enforcing a PSD matrix. 

Closes #605.

### Details and comments

