### PR TITLE
Pin ipython 

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,3 +1,4 @@
 astroid==2.5.6
 pylint==2.8.3
 numpy>=1.20.0
+ipython<8.13;python_version<'3.9'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
ipython 8.13 dropped python 3.8 support and causes CI in Qiskit Optimization breakage. See https://github.com/Qiskit/qiskit-optimization/pull/500

This PR pins ipython version and should prevent potential problems.

See also https://github.com/ipython/ipython/pull/14023
