### PR TITLE
Use seeded rng to generate regressor test data

### DIFF
--- a/test/algorithms/regressors/test_neural_network_regressor.py
+++ b/test/algorithms/regressors/test_neural_network_regressor.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2022.
+# (C) Copyright IBM 2018, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms/regressors/test_neural_network_regressor.py
+++ b/test/algorithms/regressors/test_neural_network_regressor.py
@@ -69,8 +69,9 @@ class TestNeuralNetworkRegressor(QiskitMachineLearningTestCase):
 
         # pylint: disable=invalid-name
         lb, ub = -np.pi, np.pi
-        self.X = (ub - lb) * np.random.rand(num_samples, 1) + lb
-        self.y = np.sin(self.X[:, 0]) + eps * (2 * np.random.rand(num_samples) - 1)
+        rng = np.random.default_rng(101)
+        self.X = (ub - lb) * rng.random((num_samples, 1)) + lb
+        self.y = np.sin(self.X[:, 0]) + eps * (2 * rng.random(num_samples) - 1)
 
     def tearDown(self) -> None:
         super().tearDown()

--- a/test/algorithms/regressors/test_neural_network_regressor_estimator_qnn.py
+++ b/test/algorithms/regressors/test_neural_network_regressor_estimator_qnn.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2022.
+# (C) Copyright IBM 2022, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms/regressors/test_neural_network_regressor_estimator_qnn.py
+++ b/test/algorithms/regressors/test_neural_network_regressor_estimator_qnn.py
@@ -53,8 +53,9 @@ class TestNeuralNetworkRegressor(QiskitMachineLearningTestCase):
 
         # pylint: disable=invalid-name
         lb, ub = -np.pi, np.pi
-        self.X = (ub - lb) * np.random.rand(num_samples, 1) + lb
-        self.y = np.sin(self.X[:, 0]) + eps * (2 * np.random.rand(num_samples) - 1)
+        rng = np.random.default_rng(101)
+        self.X = (ub - lb) * rng.random((num_samples, 1)) + lb
+        self.y = np.sin(self.X[:, 0]) + eps * (2 * rng.random(num_samples) - 1)
 
     def _create_regressor(
         self, opt, callback=None

--- a/test/algorithms/regressors/test_vqr.py
+++ b/test/algorithms/regressors/test_vqr.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2022.
+# (C) Copyright IBM 2018, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms/regressors/test_vqr.py
+++ b/test/algorithms/regressors/test_vqr.py
@@ -59,8 +59,9 @@ class TestVQR(QiskitMachineLearningTestCase):
 
         # pylint: disable=invalid-name
         lb, ub = -np.pi, np.pi
-        self.X = (ub - lb) * np.random.rand(num_samples, 1) + lb
-        self.y = np.sin(self.X[:, 0]) + eps * (2 * np.random.rand(num_samples) - 1)
+        rng = np.random.default_rng(101)
+        self.X = (ub - lb) * rng.random((num_samples, 1)) + lb
+        self.y = np.sin(self.X[:, 0]) + eps * (2 * rng.random(num_samples) - 1)
 
     def tearDown(self) -> None:
         super().tearDown()

--- a/test/algorithms/regressors/test_vqr_estimator_qnn.py
+++ b/test/algorithms/regressors/test_vqr_estimator_qnn.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2022.
+# (C) Copyright IBM 2022, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/test/algorithms/regressors/test_vqr_estimator_qnn.py
+++ b/test/algorithms/regressors/test_vqr_estimator_qnn.py
@@ -43,8 +43,9 @@ class TestVQR(QiskitMachineLearningTestCase):
 
         # pylint: disable=invalid-name
         lb, ub = -np.pi, np.pi
-        self.X = (ub - lb) * np.random.rand(num_samples, 1) + lb
-        self.y = np.sin(self.X[:, 0]) + eps * (2 * np.random.rand(num_samples) - 1)
+        rng = np.random.default_rng(101)
+        self.X = (ub - lb) * rng.random((num_samples, 1)) + lb
+        self.y = np.sin(self.X[:, 0]) + eps * (2 * rng.random(num_samples) - 1)
 
     @data(
         # optimizer, has ansatz


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Regressor tests sometimes fail with a message like this

>AssertionError: -3.743118339666668 not greater than 0.5

I have switched the tests such that instead of using truly random data each time it uses a fixed random set determined by  seeding that hopefully will avoid this random failure showing up.


### Details and comments


