### PR TITLE
[Stable] Fix numpy error: setting an array element with a sequence

### DIFF
--- a/qiskit_machine_learning/datasets/dataset_helper.py
+++ b/qiskit_machine_learning/datasets/dataset_helper.py
@@ -1,6 +1,6 @@
 # This code is part of Qiskit.
 #
-# (C) Copyright IBM 2018, 2022.
+# (C) Copyright IBM 2018, 2023.
 #
 # This code is licensed under the Apache License, Version 2.0. You may
 # obtain a copy of this license in the LICENSE.txt file in the root directory

--- a/qiskit_machine_learning/datasets/dataset_helper.py
+++ b/qiskit_machine_learning/datasets/dataset_helper.py
@@ -121,7 +121,7 @@ def discretize_and_truncate(
                     temp.append(grid_element + [element_current])
             grid_elements = deepcopy(temp)
             data_grid.append(elements_current_dim)
-    data_grid = np.array(data_grid)
+    data_grid = np.array(data_grid, dtype=object)
 
     data = np.reshape(data, (len(data), len(data[0])))
 

--- a/releasenotes/notes/fix-numpy-24066f33184e6e19.yaml
+++ b/releasenotes/notes/fix-numpy-24066f33184e6e19.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    The function :func:`qiskit_machine_learning.datasets.discretize_and_truncate` is fixed on
+    ``numpy`` version 1.24. This function is used by the QGAN implementation.


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The QGAN tests fail under numpy 1.24 with an error: "ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (2,) + inhomogeneous part."
This PR fixes this issue.


