### PR TITLE
Add num_input_parameters and num_weight_parameters to QNNCircuit

### DIFF
--- a/qiskit_machine_learning/circuit/library/qnn_circuit.py
+++ b/qiskit_machine_learning/circuit/library/qnn_circuit.py
@@ -232,6 +232,15 @@ class QNNCircuit(BlueprintCircuit):
         return self._feature_map.parameters
 
     @property
+    def num_input_parameters(self) -> int:
+        """Returns the number of input parameters in the circuit.
+
+        Returns:
+            The number of input parameters.
+        """
+        return len(self._feature_map.parameters)
+
+    @property
     def weight_parameters(self) -> ParameterView:
         """Returns the parameters of the ansatz. These corresponding to the trainable weights.
 
@@ -239,3 +248,12 @@ class QNNCircuit(BlueprintCircuit):
             The parameters of the ansatz.
         """
         return self._ansatz.parameters
+
+    @property
+    def num_weight_parameters(self) -> int:
+        """Returns the number of weights in the circuit.
+
+        Returns:
+            The number of weights.
+        """
+        return len(self._ansatz.parameters)

--- a/test/circuit/library/test_qnn_circuit.py
+++ b/test/circuit/library/test_qnn_circuit.py
@@ -36,6 +36,8 @@ class TestQNNCircuit(QiskitMachineLearningTestCase):
             self.assertEqual(circuit.feature_map.num_qubits, 2)
             self.assertEqual(type(circuit.ansatz), RealAmplitudes)
             self.assertEqual(circuit.ansatz.num_qubits, 2)
+            self.assertEqual(circuit.num_input_parameters, 2)
+            self.assertEqual(circuit.num_weight_parameters, 8)
 
     def test_construction_fails(self):
         """Test the faulty construction"""
@@ -64,6 +66,8 @@ class TestQNNCircuit(QiskitMachineLearningTestCase):
             self.assertEqual(circuit.feature_map.num_qubits, 1)
             self.assertEqual(type(circuit.ansatz), RealAmplitudes)
             self.assertEqual(circuit.ansatz.num_qubits, 1)
+            self.assertEqual(circuit.num_input_parameters, 1)
+            self.assertEqual(circuit.num_weight_parameters, 4)
 
     def test_feature_map_construction(self):
         """Test building the ``QNNCircuit`` with a feature map"""
@@ -115,6 +119,8 @@ class TestQNNCircuit(QiskitMachineLearningTestCase):
             self.assertEqual(circuit.num_qubits, 4)
             self.assertEqual(circuit.feature_map.num_qubits, 4)
             self.assertEqual(circuit.ansatz.num_qubits, 4)
+            self.assertEqual(circuit.num_input_parameters, 4)
+            self.assertEqual(circuit.num_weight_parameters, 16)
 
     def test_ansatz_setter(self):
         """Test the properties after the ansatz is updated."""
@@ -127,6 +133,8 @@ class TestQNNCircuit(QiskitMachineLearningTestCase):
             self.assertEqual(circuit.num_qubits, 3)
             self.assertEqual(circuit.feature_map.num_qubits, 3)
             self.assertEqual(circuit.ansatz.num_qubits, 3)
+            self.assertEqual(circuit.num_input_parameters, 3)
+            self.assertEqual(circuit.num_weight_parameters, 24)
         with self.subTest("check updated ansatz"):
             self.assertEqual(type(circuit.feature_map), PauliFeatureMap)
             self.assertEqual(type(circuit.ansatz), EfficientSU2)
@@ -144,6 +152,8 @@ class TestQNNCircuit(QiskitMachineLearningTestCase):
             self.assertEqual(circuit.num_qubits, 1)
             self.assertEqual(circuit.feature_map.num_qubits, 1)
             self.assertEqual(circuit.ansatz.num_qubits, 1)
+            self.assertEqual(circuit.num_input_parameters, 1)
+            self.assertEqual(circuit.num_weight_parameters, 4)
         with self.subTest("check updated ansatz"):
             self.assertEqual(type(circuit.feature_map), ZFeatureMap)
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR adds two convenient properties to `QNNCircuit`:
- `num_input_parameters` - the number of input parameters.
- `num_weight_parameters` - the number of trainable weights.